### PR TITLE
/stmts/{s}/{p}/{o}/discos now returns 404 when no match

### DIFF
--- a/api/src/main/java/info/rmapproject/api/responsemgr/StatementResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/StatementResponseManager.java
@@ -282,6 +282,9 @@ public class StatementResponseManager extends ResponseManager {
 			if (matchingObjects == null){
 				throw new RMapApiException(ErrorCode.ER_CORE_COULDNT_RETRIEVE_STMT_ASSERTINGAGTS);
 			}
+			if (matchingObjects.size()==0){
+				throw new RMapApiException(ErrorCode.ER_STMT_NOT_FOUND);
+			}
 
 			ResponseBuilder responseBldr = null;
 			

--- a/api/src/test/java/info/rmapproject/api/responsemgr/StatementResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/StatementResponseManagerTest.java
@@ -146,8 +146,45 @@ public class StatementResponseManagerTest extends ResponseManagerTest {
 			e.printStackTrace();	
 		}
 		
-	}
+	}	
 	
+
+	/**
+	 * Test get statement related DiSCOs where there are no matches
+	 */
+	@Test
+	public void testGetStatementRelatedDiSCOsNoMatches() {
+		Response response = null;
+		try {
+			//createDisco
+			InputStream rdf = new ByteArrayInputStream(genericDiscoRdf.getBytes(StandardCharsets.UTF_8));
+			RMapDiSCO rmapDisco = rdfHandler.rdf2RMapDiSCO(rdf, RDFType.RDFXML, "");
+			String discoURI = rmapDisco.getId().toString();
+	        assertNotNull(discoURI);
+			rmapService.createDiSCO(rmapDisco, super.reqAgent);
+			
+			RMapSearchParams params = new RMapSearchParams();
+			params.setStatusCode(RMapStatusFilter.ACTIVE);
+
+
+			MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+			//queryParams.add("page", "1");
+			
+			//get disco as related to statement
+			response = statementResponseManager.getStatementRelatedDiSCOs("http://dx.doi.org/10.1109/fail", 
+															"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", 
+															"http://purl.org/spar/fabio/fail", NonRdfType.JSON, queryParams);
+
+			assertNotNull(response);
+			assertEquals(response.getStatus(),404); //Not found 404 is appropriate response.
+			
+			rmapService.deleteDiSCO(rmapDisco.getId().getIri(), super.reqAgent);
+			
+		} catch (Exception e) {
+			e.printStackTrace();	
+		}
+		
+	}
 	
 	/**
 	 * Test get statement asserting Agents.
@@ -171,6 +208,36 @@ public class StatementResponseManagerTest extends ResponseManagerTest {
 			assertNotNull(response);
 			assertEquals(response.getStatus(),200);
 			assertEquals(response.getEntity(),"{\""+ Terms.RMAP_AGENT_PATH + "\":[\"" + super.testAgentURI + "\"]}");
+			rmapService.deleteDiSCO(new URI(discoURI), super.reqAgent);
+		} catch (Exception e) {
+			e.printStackTrace();	
+		}
+
+	}
+	
+	
+	/**
+	 * Test get statement asserting Agents.
+	 */
+	@Test
+	public void testGetStatementAssertingAgentsNoMatches() {
+		Response response = null;
+		try {			
+			//createDisco
+			InputStream rdf = new ByteArrayInputStream(genericDiscoRdf.getBytes(StandardCharsets.UTF_8));
+			RMapDiSCO rmapDisco = rdfHandler.rdf2RMapDiSCO(rdf, RDFType.RDFXML, "");
+			String discoURI = rmapDisco.getId().toString();
+	        assertNotNull(discoURI);
+			rmapService.createDiSCO(rmapDisco, super.reqAgent);
+
+			MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+			response = 
+					statementResponseManager.getStatementAssertingAgents("http://dx.doi.org/10.1109/fake", 
+														"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", 
+														"http://purl.org/spar/fabio/fake", NonRdfType.JSON, queryParams);
+			assertNotNull(response);
+			assertEquals(response.getStatus(),404);
+			
 			rmapService.deleteDiSCO(new URI(discoURI), super.reqAgent);
 		} catch (Exception e) {
 			e.printStackTrace();	

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
@@ -237,7 +237,7 @@ public class ORMapService implements RMapService {
 		org.openrdf.model.IRI cUri = ORAdapter.uri2OpenRdfIri(discoUri);
 		Set<URI> returnSet = null;
 		Set<org.openrdf.model.IRI> uris = resourcemgr.getResourceRdfTypes(rUri,cUri, triplestore);
-		if (uris != null && uris.size()>0){
+		if (uris != null){
 			returnSet = ORAdapter.openRdfIriSet2UriSet(uris);
 		}
 		return returnSet;
@@ -296,7 +296,7 @@ public class ORMapService implements RMapService {
 				statementmgr.getRelatedDiSCOs(orSubject, orPredicate, orObject, params, triplestore);
 				
 		List<URI> returnSet = null;
-		if (relatedDiSCOs != null && relatedDiSCOs.size()>0){
+		if (relatedDiSCOs != null){
 			returnSet = ORAdapter.openRdfUriList2UriList(relatedDiSCOs);
 		}		
 		return returnSet;
@@ -328,7 +328,7 @@ public class ORMapService implements RMapService {
 				statementmgr.getAssertingAgents(orSubject, orPredicate, orObject, params, triplestore);
 		
 		List<URI> returnSet = null;
-		if (assertingAgents != null && assertingAgents.size()>0){
+		if (assertingAgents != null){
 			returnSet = new ArrayList<URI>();
 			for (IRI uri:assertingAgents){
 				returnSet.add(ORAdapter.openRdfIri2URI(uri));


### PR DESCRIPTION
Fix for issue #2.  Applied fix to both /discos and /agents. Now returns 404 error if statement doesn't exist.