### PR TITLE
Handle invalid URIs in search form

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/views/search.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/search.jsp
@@ -21,7 +21,10 @@
 	<form:label path="search">Enter a URI *</form:label> 
 	<form:input path="search" style="width:320px;float:left;margin-right:10px;" value="${searchVal}"/>
 	<input type="submit" value="GO" style="margin-top:3px;">
-	<p style="font-size: 85%;">Examples: rmap:rmd18n8xfs, http://dx.doi.org/10.1109/InPar.2012.6339604, https://osf.io/rxgmb/</p><br/>
+	<p style="font-size: 85%;">Examples: 
+	<a href="<c:url value='/resources/rmap%3Armd18n8xfs'/>">rmap:rmd18n8xfs</a>, 
+	<a href="<c:url value='/resources/http%3A%2F%2Fdx.doi.org%2F10.1109%2FInPar.2012.6339604'/>">http://dx.doi.org/10.1109/InPar.2012.6339604</a>, 
+	<a href="<c:url value='/resources/https%3A%2F%2Fosf.io%2Frxgmb%2F'/>">https://osf.io/rxgmb/</a></p><br/>
 </form:form>
 <br/>
 <br/>

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -27,4 +27,22 @@
         <tracking-mode>COOKIE</tracking-mode>
         <session-timeout>60</session-timeout>
     </session-config>  
+    
+    <filter>
+	    <filter-name>CharacterEncodingFilter</filter-name>
+	    <filter-class>org.springframework.web.filter.CharacterEncodingFilter</filter-class>
+	    <init-param>
+	        <param-name>encoding</param-name>
+	        <param-value>UTF-8</param-value>
+	    </init-param>
+	    <init-param>
+	        <param-name>forceEncoding</param-name>
+	        <param-value>true</param-value>
+	    </init-param>
+	</filter>
+	<filter-mapping>
+	    <filter-name>CharacterEncodingFilter</filter-name>
+	    <url-pattern>/*</url-pattern>
+	</filter-mapping>
+    
 </web-app>


### PR DESCRIPTION
Fixes https://github.com/rmap-project/rmap/issues/6

Previously, a search on an invalid URI would fail with a generic error.  The user is now redirected back to the search form with a notice saying that an invalid URI was provided. Removed some unnecessary decode commands. Also made the example URIs into links so they stand out.
