### PR TITLE
Maven parent pom (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.idea
+*.iws
+*.ipr
+*.iml
+.project
+.classpath
+target/

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,81 +1,73 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>info.rmapproject</groupId>
+
+	<parent>
+		<groupId>info.rmapproject</groupId>
+		<artifactId>rmap-parent</artifactId>
+		<version>1.0.1-beta-SNAPSHOT</version>
+	</parent>
+
 	<artifactId>rmap-api</artifactId>
 	<packaging>war</packaging>
-	<version>1.0.1-beta-SNAPSHOT</version>
-	<name>RMap Project</name>
-	<url>http://rmap-project.info</url>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<org.springframework-version>4.1.6.RELEASE</org.springframework-version>
-		<jackson.version>2.7.4</jackson.version>
-	</properties>
+
+	<name>RMap API</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>info.rmapproject</groupId>
 			<artifactId>rmap-auth</artifactId>
-			<version>1.0.1-beta-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>info.rmapproject</groupId>
 			<artifactId>rmap-core</artifactId>
-			<version>1.0.1-beta-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.1.7</version>
 		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-frontend-jaxrs</artifactId>
-			<version>3.1.4</version>
 		</dependency>
 
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>3.1.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
 			<artifactId>jackson-jaxrs-json-provider</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>${org.springframework-version}</version>
 		</dependency>
 		
 		<!-- testing only -->
@@ -83,21 +75,19 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
-			<version>${org.springframework-version}</version>
         	<scope>test</scope>
 		</dependency>
 		
         <dependency>
         	<groupId>info.rmapproject</groupId>
         	<artifactId>rmap-testdata</artifactId>
-            <version>1.0.1-beta-SNAPSHOT</version>
-        	<scope>test</scope>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
         </dependency>
 		
 		<dependency>
 		    <groupId>org.mockito</groupId>
 		    <artifactId>mockito-core</artifactId>
-		    <version>2.7.13</version>
         	<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -106,11 +96,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
 			</plugin>
 
 		</plugins>

--- a/api/src/test/java/info/rmapproject/api/utils/HttpHeaderDateUtilsTest.java
+++ b/api/src/test/java/info/rmapproject/api/utils/HttpHeaderDateUtilsTest.java
@@ -11,12 +11,14 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author khanson5
  *
  */
+@Ignore("TODO: Pending resolution of #46")
 public class HttpHeaderDateUtilsTest {
 
 	private Date dTestdate1;

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -2,84 +2,66 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>info.rmapproject</groupId>
+
+    <parent>
+        <groupId>info.rmapproject</groupId>
+        <artifactId>rmap-parent</artifactId>
+        <version>1.0.1-beta-SNAPSHOT</version>
+    </parent>
+
     <artifactId>rmap-auth</artifactId>
-    <name>auth</name>
-    <version>1.0.1-beta-SNAPSHOT</version>
-    <properties>
-        <java-version>1.8</java-version>
-        <org.springframework-version>4.1.6.RELEASE</org.springframework-version>
-        <org.aspectj-version>1.6.10</org.aspectj-version>
-        <org.slf4j-version>1.6.6</org.slf4j-version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+    <name>RMap Auth</name>
+
     <dependencies>
         <dependency>
             <groupId>info.rmapproject</groupId>
             <artifactId>rmap-core</artifactId>
-            <version>1.0.1-beta-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <!-- logging -->
 	    <dependency>
 	      <groupId>ch.qos.logback</groupId>
 	      <artifactId>logback-classic</artifactId>
-	      <version>1.1.7</version>
 	    </dependency>
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${org.springframework-version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${org.springframework-version}</version>
-            <exclusions>
-                <!-- Exclude Commons Logging in favor of SLF4j -->
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-            <version>${org.springframework-version}</version>
-        </dependency>	
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${org.springframework-version}</version>
-        </dependency>	
+        </dependency>
         <!-- Spring ORM -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
-            <version>${org.springframework-version}</version>
         </dependency>
         
         <!-- db / hibernate -->	
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>4.3.11.Final</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
-            <version>4.3.11.Final</version>
         </dependency>			  	
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>4.3.2.Final</version>
         </dependency>        
         <dependency> 
             <groupId>commons-dbcp</groupId> 
-            <artifactId>commons-dbcp</artifactId> 
-            <version>1.4</version> 
+            <artifactId>commons-dbcp</artifactId>
         </dependency>
         
         
@@ -87,21 +69,18 @@
 		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjrt</artifactId>
-			<version>${org.aspectj-version}</version>
 		</dependency>
         
         <!-- needed for testing db on desktop -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.6</version>
         </dependency>
         
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.7</version>
             <scope>test</scope>
         </dependency>     
     </dependencies>
@@ -111,7 +90,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>
@@ -120,14 +98,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <compilerArgument>-Xlint:all</compilerArgument>
-                    <showWarnings>true</showWarnings>
-                    <showDeprecation>true</showDeprecation>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,27 +1,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>info.rmapproject</groupId>
+
+    <parent>
+        <groupId>info.rmapproject</groupId>
+        <artifactId>rmap-parent</artifactId>
+        <version>1.0.1-beta-SNAPSHOT</version>
+    </parent>
+
     <artifactId>rmap-core</artifactId>
     <name>RMap Core</name>
-    <version>1.0.1-beta-SNAPSHOT</version>
-    <properties>
-        <java-version>1.8</java-version>
-        <org.springframework-version>4.1.6.RELEASE</org.springframework-version>
-        <org.powermock-version>1.6.6</org.powermock-version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <dependencies>
     	<!-- logging-->
 	    <dependency>
 	      <groupId>ch.qos.logback</groupId>
 	      <artifactId>logback-classic</artifactId>
-	      <version>1.1.7</version>
 	    </dependency>
         <!-- sesame framework -->
        <dependency>
             <groupId>org.openrdf.sesame</groupId>
             <artifactId>sesame-runtime</artifactId>
-            <version>4.1.1</version>
         </dependency>
         <!-- note - there are several libraries that are packaged in sesame but an older version is 
 	  	referenced that does not support all sesame functions!  This will probably be fixed in a 
@@ -29,62 +27,52 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.jsonld-java</groupId>
             <artifactId>jsonld-java</artifactId>
-            <version>0.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.0</version>
-        </dependency>	  	
+        </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
-            <version>1.10</version>
         </dependency>
         <!-- spring framework -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${org.springframework-version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${org.springframework-version}</version>
         </dependency>	
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${org.springframework-version}</version>
         </dependency>
         <!-- testing -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
         	<groupId>info.rmapproject</groupId>
         	<artifactId>rmap-testdata</artifactId>
-            <version>1.0.1-beta-SNAPSHOT</version>
-        	<scope>test</scope>
+            <scope>test</scope>
         </dependency>	
 		<dependency>
 		    <groupId>org.powermock</groupId>
 		    <artifactId>powermock-api-mockito</artifactId>
-		    <version>${org.powermock-version}</version>
 		    <scope>test</scope>
 		</dependency>
 		<dependency>
 		    <groupId>org.powermock</groupId>
 		    <artifactId>powermock-module-junit4</artifactId>
-		    <version>${org.powermock-version}</version>
+            <scope>test</scope>
 		</dependency>
     </dependencies>
     <build>
@@ -92,14 +80,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <compilerArgument>-Xlint:all</compilerArgument>
-                    <showWarnings>true</showWarnings>
-                    <showDeprecation>true</showDeprecation>
-                </configuration>
             </plugin>
             <!--  skip tests...
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,297 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>info.rmapproject</groupId>
+    <artifactId>rmap-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.1-beta-SNAPSHOT</version>
+
+    <name>RMap Project</name>
+    <url>http://rmap-project.info</url>
+
+    <modules>
+        <module>api</module>
+        <module>core</module>
+        <module>auth</module>
+        <module>testdata</module>
+        <module>webapp</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <java-version>1.8</java-version>
+        <org.springframework-version>4.1.6.RELEASE</org.springframework-version>
+        <org.aspectj-version>1.6.10</org.aspectj-version>
+        <org.powermock-version>1.6.6</org.powermock-version>
+        <org.slf4j-version>1.6.6</org.slf4j-version>
+        <jackson.version>2.7.4</jackson.version>
+        <logback.version>1.1.7</logback.version>
+        <openrdf.version>4.1.1</openrdf.version>
+        <httpclient.version>4.5.2</httpclient.version>
+        <jsonld-java.version>0.5.1</jsonld-java.version>
+        <commons-collections.version>4.0</commons-collections.version>
+        <commons-configuration.version>1.10</commons-configuration.version>
+        <commons-dbcp.version>1.4</commons-dbcp.version>
+        <junit.version>4.11</junit.version>
+        <jstl.version>1.2</jstl.version>
+        <jsp-api.version>2.1</jsp-api.version>
+        <servlet-api.version>3.1.0</servlet-api.version>
+        <jsoup.version>1.8.3</jsoup.version>
+        <hibernate.version>4.3.11.Final</hibernate.version>
+        <hibernate-validator.version>4.3.2.Final</hibernate-validator.version>
+        <mysql-connector.version>5.1.6</mysql-connector.version>
+        <mockito.version>1.10.19</mockito.version>
+        <scribejava.version>2.1.0</scribejava.version>
+        <org-json.version>20151123</org-json.version>
+        <apache-cxf.version>3.1.4</apache-cxf.version>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.5.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <compilerArgument>-Xlint:all</compilerArgument>
+                        <showWarnings>true</showWarnings>
+                        <showDeprecation>true</showDeprecation>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.18.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- logging impl -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+
+            <!-- sesame framework -->
+
+            <!-- note - there are several libraries that are packaged in sesame but an older version is
+                referenced that does not support all sesame functions!  This will probably be fixed in a
+                future version of sesame runtime, for now we need these -->
+            <dependency>
+                <groupId>org.openrdf.sesame</groupId>
+                <artifactId>sesame-runtime</artifactId>
+                <version>${openrdf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jsonld-java</groupId>
+                <artifactId>jsonld-java</artifactId>
+                <version>${jsonld-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>${commons-collections.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-configuration</groupId>
+                <artifactId>commons-configuration</artifactId>
+                <version>${commons-configuration.version}</version>
+            </dependency>
+
+            <!-- spring framework -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${org.springframework-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${org.springframework-version}</version>
+                <exclusions>
+                    <!-- Exclude Commons Logging in favor of SLF4j -->
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${org.springframework-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${org.springframework-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>${org.springframework-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-tx</artifactId>
+                <version>${org.springframework-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-orm</artifactId>
+                <version>${org.springframework-version}</version>
+            </dependency>
+
+            <!-- testing -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.rmapproject</groupId>
+                <artifactId>rmap-testdata</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${org.powermock-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${org.powermock-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>1.10.19</version>
+            </dependency>
+
+            <!-- webapp -->
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${org-json.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
+            </dependency>
+
+            <!-- oauth plugin -->
+            <dependency>
+                <groupId>com.github.scribejava</groupId>
+                <artifactId>scribejava-apis</artifactId>
+                <version>${scribejava.version}</version>
+            </dependency>
+
+            <!-- servlet-related apis -->
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${servlet-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet.jsp</groupId>
+                <artifactId>jsp-api</artifactId>
+                <version>${jsp-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>jstl</artifactId>
+                <version>${jstl.version}</version>
+            </dependency>
+
+            <!-- db / hibernate -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-entitymanager</artifactId>
+                <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate-validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-dbcp</groupId>
+                <artifactId>commons-dbcp</artifactId>
+                <version>${commons-dbcp.version}</version>
+            </dependency>
+            <!-- needed for testing db on desktop -->
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${mysql-connector.version}</version>
+            </dependency>
+
+
+            <!-- AspectJ -->
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjrt</artifactId>
+                <version>${org.aspectj-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+                <version>${apache-cxf.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/testdata/pom.xml
+++ b/testdata/pom.xml
@@ -1,17 +1,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>info.rmapproject</groupId>
+
+    <parent>
+        <groupId>info.rmapproject</groupId>
+        <artifactId>rmap-parent</artifactId>
+        <version>1.0.1-beta-SNAPSHOT</version>
+    </parent>
+
   <artifactId>rmap-testdata</artifactId>
-  <version>1.0.1-beta-SNAPSHOT</version>
-  <properties>
-        <java-version>1.8</java-version>
-  </properties>
-  <name>testdata</name>
+  <name>RMap test data</name>
+
   <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>
   </dependencies>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -2,84 +2,75 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>info.rmapproject</groupId>
+
+    <parent>
+        <groupId>info.rmapproject</groupId>
+        <artifactId>rmap-parent</artifactId>
+        <version>1.0.1-beta-SNAPSHOT</version>
+    </parent>
+
     <artifactId>rmap-webapp</artifactId>
-    <name>webapp</name>
+    <name>RMap Webapp</name>
     <packaging>war</packaging>
-    <version>1.0.1-beta-SNAPSHOT</version>
-    <properties>
-        <java-version>1.8</java-version>
-        <org.springframework-version>4.1.6.RELEASE</org.springframework-version>
-        <org.aspectj-version>1.6.10</org.aspectj-version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>info.rmapproject</groupId>
             <artifactId>rmap-core</artifactId>
-            <version>1.0.1-beta-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>info.rmapproject</groupId>
             <artifactId>rmap-auth</artifactId>
-            <version>1.0.1-beta-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <!-- logging -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
         </dependency>
         
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${org.springframework-version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>${org.springframework-version}</version>
         </dependency>
         
         
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20151123</version>
         </dependency>
         
         <!-- oauth plugin -->
         <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-apis</artifactId>
-            <version>2.1.0</version>
         </dependency>
         
         <!-- Servlet -->
 		<dependency>
 		    <groupId>javax.servlet</groupId>
 		    <artifactId>javax.servlet-api</artifactId>
-		    <version>3.1.0</version>
             <scope>provided</scope>
 		</dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
-            <version>2.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <version>1.2</version>
         </dependency>
         <!-- used for parsing string to remove html tags. -->
 		<dependency>
 		    <groupId>org.jsoup</groupId>
 		    <artifactId>jsoup</artifactId>
-		    <version>1.8.3</version>
 		</dependency>
         
         
@@ -87,14 +78,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>     
         <dependency>
         	<groupId>info.rmapproject</groupId>
         	<artifactId>rmap-testdata</artifactId>
-            <version>1.0.1-beta-SNAPSHOT</version>
-        	<scope>test</scope>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
         </dependency>	
     </dependencies>
     
@@ -103,17 +93,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <!--  temp -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>


### PR DESCRIPTION
- Collapse properties to the parent pom
- Use property placeholders for versions of dependencies
- Move dependency boilerplate to parent pom (plugin and dependency management)
- Add .gitignore