### PR TITLE
Avoid a ClassCastException when the officialAgentId is null.

### DIFF
--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapAgent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapAgent.java
@@ -165,7 +165,6 @@ public class ORMapAgent extends ORMapObject implements RMapAgent {
 		//if agent has come in without a context, generate ID. This will happen if it's a new agent
 		if (officialAgentId==null || officialAgentId.stringValue().length()==0){
 			this.setId();
-			officialAgentId = (Resource) this.getId();
 		}
 		else {
 			this.setId((IRI) officialAgentId);


### PR DESCRIPTION
Removes un-used field, and avoids a ClassCastException when the graph identifier (i.e. officialAgentId) is null.

Closes #90.