### PR TITLE
Support N-Quad parsing.

### DIFF
--- a/core/src/main/java/info/rmapproject/core/rdfhandler/RDFType.java
+++ b/core/src/main/java/info/rmapproject/core/rdfhandler/RDFType.java
@@ -33,7 +33,10 @@ public enum RDFType {
 	RDFXML("RDFXML"), 
 	
 	/** RDF Turtle see https://www.w3.org/TR/turtle/ */
-	TURTLE("TURTLE");
+	TURTLE("TURTLE"),
+
+	/** N-Quads see https://www.w3.org/TR/n-quads/ */
+	NQUADS("NQUADS");
 	
 	/** String representation of RDF type. */
 	private final String rdfType;

--- a/core/src/main/java/info/rmapproject/core/rdfhandler/impl/openrdf/RioRDFHandler.java
+++ b/core/src/main/java/info/rmapproject/core/rdfhandler/impl/openrdf/RioRDFHandler.java
@@ -125,7 +125,7 @@ public class RioRDFHandler implements RDFHandler {
 		try {
 			rdfParser.parse(rdfIn, baseUri);
 		} catch (RDFParseException | RDFHandlerException | IOException e) {
-			throw new RMapException("Unable to parse input RDF: ",e);
+			throw new RMapException("Unable to parse input RDF: " + e.getMessage(), e);
 		}		
 		
 		//Need to do last check to make sure IRIs are compatible with java.net.URI format. 
@@ -284,6 +284,8 @@ public class RioRDFHandler implements RDFHandler {
                      break;
             case JSONLD:  rdfFormat = RDFFormat.JSONLD;
                      break;
+			case NQUADS:  rdfFormat = RDFFormat.NQUADS;
+					 break;
             default: rdfFormat = RDFFormat.TURTLE;
                      break;
         }


### PR DESCRIPTION
Support N-Quad parsing by adding the RMap `RDFType.NQUADS` and mapping it to the OpenRDF model type `RDFFormat.NQUADS`.

Closes #92.