### PR TITLE
Update the RMap domain objects to support java.io.Serializable

### DIFF
--- a/core/src/main/java/info/rmapproject/core/model/RMapBlankNode.java
+++ b/core/src/main/java/info/rmapproject/core/model/RMapBlankNode.java
@@ -75,5 +75,19 @@ public class RMapBlankNode extends RMapResource {
 		return getStringValue();
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		RMapBlankNode that = (RMapBlankNode) o;
+
+		return id != null ? id.equals(that.id) : that.id == null;
+	}
+
+	@Override
+	public int hashCode() {
+		return id != null ? id.hashCode() : 0;
+	}
 
 }

--- a/core/src/main/java/info/rmapproject/core/model/RMapResource.java
+++ b/core/src/main/java/info/rmapproject/core/model/RMapResource.java
@@ -22,6 +22,8 @@
  */
 package info.rmapproject.core.model;
 
+import java.io.Serializable;
+
 /**
  * Models the concept of an RDF Resource.  RDF Resources can be 
  * represented by a Blank Node (see RMapBlankNode) or an IRI (see RMapIri)
@@ -29,7 +31,9 @@ package info.rmapproject.core.model;
  *
  * @author smorrissey
  */
-public abstract class RMapResource implements RMapValue{
+public abstract class RMapResource implements RMapValue, Serializable {
+
+	private static long serialVersionUID = 1L;
 
 	/**
 	 * Instantiates a new RMap resource.

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapAgent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapAgent.java
@@ -249,5 +249,35 @@ public class ORMapAgent extends ORMapObject implements RMapAgent {
 		this.authIdStmt = stmt;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
 
+		ORMapAgent that = (ORMapAgent) o;
+
+		if (nameStmt != null ? !nameStmt.equals(that.nameStmt) : that.nameStmt != null) return false;
+		if (idProviderStmt != null ? !idProviderStmt.equals(that.idProviderStmt) : that.idProviderStmt != null)
+			return false;
+		return authIdStmt != null ? authIdStmt.equals(that.authIdStmt) : that.authIdStmt == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (nameStmt != null ? nameStmt.hashCode() : 0);
+		result = 31 * result + (idProviderStmt != null ? idProviderStmt.hashCode() : 0);
+		result = 31 * result + (authIdStmt != null ? authIdStmt.hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "ORMapAgent{" +
+				"nameStmt=" + nameStmt +
+				", idProviderStmt=" + idProviderStmt +
+				", authIdStmt=" + authIdStmt +
+				"} " + super.toString();
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapDiSCO.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapDiSCO.java
@@ -321,7 +321,7 @@ public class ORMapDiSCO extends ORMapObject implements RMapDiSCO {
 				Value vdesc = ORAdapter.rMapValue2OpenRdfValue(description);
 				stmt = ORAdapter.getValueFactory().createStatement(subject,predicate,vdesc,this.context);
 			} catch (Exception e) {
-				throw new RMapException("Error while setting DiSCO description",e);
+				throw new RMapException("Error while setting DiSCO description: " + e.getMessage(), e);
 			}
 		}
 		this.description = stmt;
@@ -581,6 +581,37 @@ public class ORMapDiSCO extends ORMapObject implements RMapDiSCO {
 			}
 			relatedStatements = newStmts;
 		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ORMapDiSCO that = (ORMapDiSCO) o;
+
+		if (aggregatedResources != null ? !aggregatedResources.equals(that.aggregatedResources) : that.aggregatedResources != null)
+			return false;
+		if (relatedStatements != null ? !relatedStatements.equals(that.relatedStatements) : that.relatedStatements != null)
+			return false;
+		if (creator != null ? !creator.equals(that.creator) : that.creator != null) return false;
+		if (description != null ? !description.equals(that.description) : that.description != null) return false;
+		if (providerIdStmt != null ? !providerIdStmt.equals(that.providerIdStmt) : that.providerIdStmt != null)
+			return false;
+		return provGeneratedByStmt != null ? provGeneratedByStmt.equals(that.provGeneratedByStmt) : that.provGeneratedByStmt == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (aggregatedResources != null ? aggregatedResources.hashCode() : 0);
+		result = 31 * result + (relatedStatements != null ? relatedStatements.hashCode() : 0);
+		result = 31 * result + (creator != null ? creator.hashCode() : 0);
+		result = 31 * result + (description != null ? description.hashCode() : 0);
+		result = 31 * result + (providerIdStmt != null ? providerIdStmt.hashCode() : 0);
+		result = 31 * result + (provGeneratedByStmt != null ? provGeneratedByStmt.hashCode() : 0);
+		return result;
 	}
 
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
@@ -492,4 +492,39 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 		}
 		return eventModel;
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ORMapEvent that = (ORMapEvent) o;
+
+		if (eventTypeStmt != null ? !eventTypeStmt.equals(that.eventTypeStmt) : that.eventTypeStmt != null)
+			return false;
+		if (eventTargetTypeStmt != null ? !eventTargetTypeStmt.equals(that.eventTargetTypeStmt) : that.eventTargetTypeStmt != null)
+			return false;
+		if (associatedAgentStmt != null ? !associatedAgentStmt.equals(that.associatedAgentStmt) : that.associatedAgentStmt != null)
+			return false;
+		if (descriptionStmt != null ? !descriptionStmt.equals(that.descriptionStmt) : that.descriptionStmt != null)
+			return false;
+		if (startTimeStmt != null ? !startTimeStmt.equals(that.startTimeStmt) : that.startTimeStmt != null)
+			return false;
+		if (endTimeStmt != null ? !endTimeStmt.equals(that.endTimeStmt) : that.endTimeStmt != null) return false;
+		return associatedKeyStmt != null ? associatedKeyStmt.equals(that.associatedKeyStmt) : that.associatedKeyStmt == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (eventTypeStmt != null ? eventTypeStmt.hashCode() : 0);
+		result = 31 * result + (eventTargetTypeStmt != null ? eventTargetTypeStmt.hashCode() : 0);
+		result = 31 * result + (associatedAgentStmt != null ? associatedAgentStmt.hashCode() : 0);
+		result = 31 * result + (descriptionStmt != null ? descriptionStmt.hashCode() : 0);
+		result = 31 * result + (startTimeStmt != null ? startTimeStmt.hashCode() : 0);
+		result = 31 * result + (endTimeStmt != null ? endTimeStmt.hashCode() : 0);
+		result = 31 * result + (associatedKeyStmt != null ? associatedKeyStmt.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
@@ -161,4 +161,21 @@ public class ORMapEventDeletion extends ORMapEvent implements RMapEventDeletion 
 		}
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ORMapEventDeletion that = (ORMapEventDeletion) o;
+
+		return deletedObjects != null ? deletedObjects.equals(that.deletedObjects) : that.deletedObjects == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (deletedObjects != null ? deletedObjects.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
@@ -252,4 +252,24 @@ public class ORMapEventDerivation extends ORMapEventWithNewObjects implements
 		return sourceObjectStatement;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ORMapEventDerivation that = (ORMapEventDerivation) o;
+
+		if (sourceObjectStatement != null ? !sourceObjectStatement.equals(that.sourceObjectStatement) : that.sourceObjectStatement != null)
+			return false;
+		return derivationStatement != null ? derivationStatement.equals(that.derivationStatement) : that.derivationStatement == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (sourceObjectStatement != null ? sourceObjectStatement.hashCode() : 0);
+		result = 31 * result + (derivationStatement != null ? derivationStatement.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
@@ -178,4 +178,21 @@ public class ORMapEventInactivation extends ORMapEvent implements
 		return model;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ORMapEventInactivation that = (ORMapEventInactivation) o;
+
+		return inactivatedObjectStatement != null ? inactivatedObjectStatement.equals(that.inactivatedObjectStatement) : that.inactivatedObjectStatement == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (inactivatedObjectStatement != null ? inactivatedObjectStatement.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
@@ -145,4 +145,21 @@ public class ORMapEventTombstone extends ORMapEvent implements
 		}
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ORMapEventTombstone that = (ORMapEventTombstone) o;
+
+		return tombstoned != null ? tombstoned.equals(that.tombstoned) : that.tombstoned == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (tombstoned != null ? tombstoned.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
@@ -236,4 +236,24 @@ public class ORMapEventUpdate extends ORMapEventWithNewObjects implements RMapEv
 		}
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ORMapEventUpdate that = (ORMapEventUpdate) o;
+
+		if (derivationStatement != null ? !derivationStatement.equals(that.derivationStatement) : that.derivationStatement != null)
+			return false;
+		return inactivatedObjectStatement != null ? inactivatedObjectStatement.equals(that.inactivatedObjectStatement) : that.inactivatedObjectStatement == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (derivationStatement != null ? derivationStatement.hashCode() : 0);
+		result = 31 * result + (inactivatedObjectStatement != null ? inactivatedObjectStatement.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
@@ -160,4 +160,21 @@ public class ORMapEventUpdateWithReplace extends ORMapEvent implements RMapEvent
 		}
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		ORMapEventUpdateWithReplace that = (ORMapEventUpdateWithReplace) o;
+
+		return updatedObjectIdStmt != null ? updatedObjectIdStmt.equals(that.updatedObjectIdStmt) : that.updatedObjectIdStmt == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (updatedObjectIdStmt != null ? updatedObjectIdStmt.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
@@ -190,5 +190,21 @@ public abstract class ORMapEventWithNewObjects extends ORMapEvent implements
 		return model;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
 
+		ORMapEventWithNewObjects that = (ORMapEventWithNewObjects) o;
+
+		return createdObjects != null ? createdObjects.equals(that.createdObjects) : that.createdObjects == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (createdObjects != null ? createdObjects.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapObject.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapObject.java
@@ -31,13 +31,17 @@ import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.RMapObject;
 import info.rmapproject.core.model.RMapObjectType;
 
+import java.io.Serializable;
+
 /**
  * Base class for OpenRDF implementation classes of RMapObjects.
  *
  * @author khanson, smorrissey
  */
-public abstract class ORMapObject implements RMapObject  {
-	
+public abstract class ORMapObject implements RMapObject, Serializable {
+
+	private static final long serialVersionUID = 1L;
+
 	/** The object unique ID. */
 	protected IRI id;
 	
@@ -156,6 +160,34 @@ public abstract class ORMapObject implements RMapObject  {
 	public IRI getContext() {
 		return context;
 	}
-	
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		ORMapObject that = (ORMapObject) o;
+
+		if (id != null ? !id.equals(that.id) : that.id != null) return false;
+		if (typeStatement != null ? !typeStatement.equals(that.typeStatement) : that.typeStatement != null)
+			return false;
+		return context != null ? context.equals(that.context) : that.context == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = id != null ? id.hashCode() : 0;
+		result = 31 * result + (typeStatement != null ? typeStatement.hashCode() : 0);
+		result = 31 * result + (context != null ? context.hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "ORMapObject{" +
+				"id=" + id +
+				", typeStatement=" + typeStatement +
+				", context=" + context +
+				'}';
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/request/RMapRequestAgent.java
+++ b/core/src/main/java/info/rmapproject/core/model/request/RMapRequestAgent.java
@@ -21,6 +21,7 @@ package info.rmapproject.core.model.request;
 
 import info.rmapproject.core.exception.RMapException;
 
+import java.io.Serializable;
 import java.net.URI;
 
 /**
@@ -29,7 +30,9 @@ import java.net.URI;
  *
  * @author khanson
  */
-public class RMapRequestAgent {
+public class RMapRequestAgent implements Serializable {
+
+	private static final long serialVersionUID = 1L;
 
 	/** The system agent. */
 	URI systemAgent;
@@ -98,7 +101,30 @@ public class RMapRequestAgent {
 	public void setAgentKeyId(URI agentKeyId) {
 		this.agentKeyId = agentKeyId;
 	}
-		
-	
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		RMapRequestAgent that = (RMapRequestAgent) o;
+
+		if (systemAgent != null ? !systemAgent.equals(that.systemAgent) : that.systemAgent != null) return false;
+		return agentKeyId != null ? agentKeyId.equals(that.agentKeyId) : that.agentKeyId == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = systemAgent != null ? systemAgent.hashCode() : 0;
+		result = 31 * result + (agentKeyId != null ? agentKeyId.hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "RMapRequestAgent{" +
+				"systemAgent=" + systemAgent +
+				", agentKeyId=" + agentKeyId +
+				'}';
+	}
 }

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapObjectMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapObjectMgr.java
@@ -61,7 +61,7 @@ public abstract class ORMapObjectMgr {
 		try {
 			ts.addStatement(stmt);
 		} catch (Exception e) {
-			throw new RMapException ("Exception thrown creating triple from ORMapStatement ", e);
+			throw new RMapException("Exception thrown creating triple from ORMapStatement: " + e.getMessage(), e);
 		}
 	}
 	

--- a/core/src/test/java/info/rmapproject/core/ObjectSerializationTest.java
+++ b/core/src/test/java/info/rmapproject/core/ObjectSerializationTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.core;
+
+import info.rmapproject.core.model.RMapBlankNode;
+import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.RMapLiteral;
+import info.rmapproject.core.model.RMapTriple;
+import info.rmapproject.core.model.event.RMapEventTargetType;
+import info.rmapproject.core.model.impl.openrdf.ORAdapter;
+import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
+import info.rmapproject.core.model.impl.openrdf.ORMapDiSCO;
+import info.rmapproject.core.model.impl.openrdf.ORMapEventCreation;
+import info.rmapproject.core.model.request.RMapRequestAgent;
+import org.junit.Test;
+import org.openrdf.model.IRI;
+import org.openrdf.model.Statement;
+import org.openrdf.model.Value;
+import org.openrdf.sail.memory.model.MemValueFactory;
+
+import java.util.List;
+
+import static info.rmapproject.core.SerializationAssertions.serializeTest;
+import static info.rmapproject.core.TestUtil.asRmapLiteral;
+import static info.rmapproject.core.TestUtil.count;
+import static java.net.URI.create;
+import static java.util.Collections.singletonList;
+
+/**
+ * The various RMap service interfaces hide various implementations, from the OpenRDF ValueFactory used to create
+ * statements, to the myriad constructors and objects used to construct RMap domain objects.  This unit test
+ * does a first pass insuring that the domain object constructors produce objects that can be (de)serialized by the JVM
+ * {@link java.io.ObjectOutputStream} and {@link java.io.ObjectInputStream}.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class ObjectSerializationTest {
+
+    @Test
+    public void serializeDisco() throws Exception {
+        RMapIri agentIri = TestUtil.asRmapIri("http://example.com/agent/" + count());
+        IRI discoIri = TestUtil.asIri("http://example.com/disco/" + count());
+        RMapIri provIri = TestUtil.asRmapIri("http://exmaple.com/agent/" + count());
+        RMapIri resourceIri = TestUtil.asRmapIri("http://exmaple.com/resource/" + count());
+
+        ORMapDiSCO expectedDisco = new ORMapDiSCO(discoIri, agentIri,
+                singletonList(create("http://foo.com/bar/resource")));
+
+        expectedDisco.setDescription(new RMapLiteral("a description"));
+        expectedDisco.setProvGeneratedBy(provIri);
+        expectedDisco.setRelatedStatements(singletonList(new RMapTriple(resourceIri, provIri,
+                asRmapLiteral("a value"))));
+
+        serializeTest(expectedDisco);
+    }
+
+    @Test
+    public void serializeAgent() throws Exception {
+        IRI agentIri = TestUtil.asIri("http://example.com/agent/" + count());
+        IRI providerIri = TestUtil.asIri("http://example.com/provider/" + count());
+        IRI authIri = TestUtil.asIri("http://example.com/authid/" + count());
+        // Value needs to be implemented by something other than an inner class
+        Value agentName = ORAdapter.getValueFactory().createLiteral("An Agent");
+
+        ORMapAgent agent = new ORMapAgent(agentIri, providerIri, authIri, agentName);
+
+        serializeTest(agent);
+    }
+
+    @Test
+    public void serializeEventCreation() throws Exception {
+        IRI eventIri = TestUtil.asIri("http://example.com/event/" + count());
+        RMapRequestAgent requestAgent = new RMapRequestAgent(create("http://example.org/agent/" + count()),
+                create("http://example.org/agent/key"));
+        RMapEventTargetType type = RMapEventTargetType.DISCO;
+        RMapLiteral desc = new RMapLiteral("Creation Event Description");
+        List<RMapIri> created = singletonList(TestUtil.asRmapIri("http://example.org/disco/" + count()));
+
+        ORMapEventCreation event = new ORMapEventCreation(eventIri, requestAgent, type, desc, created);
+
+        serializeTest(event);
+    }
+
+    @Test
+    public void serializeRmapIri() throws Exception {
+        RMapIri iri = TestUtil.asRmapIri("http://example.com/event/" + count());
+        serializeTest(iri);
+    }
+
+    @Test
+    public void serializeIri() throws Exception {
+        IRI iri = TestUtil.asIri("http://example.com/event/" + count());
+        serializeTest(iri);
+    }
+
+    @Test
+    public void serializeRmapBlankNode() throws Exception {
+        RMapBlankNode node = new RMapBlankNode("id");
+        serializeTest(node);
+    }
+
+    @Test
+    public void serializeStatement() throws Exception {
+        MemValueFactory mvf = new MemValueFactory();
+
+        Statement s = mvf.createStatement(
+                TestUtil.asIri("http://example.org/subject"),
+                TestUtil.asIri("http://example.org/predicate"),
+                mvf.createLiteral("a value"));
+
+        serializeTest(s);
+
+        s = mvf.createStatement(
+                TestUtil.asIri("http://example.org/subject"),
+                TestUtil.asIri("http://example.org/predicate"),
+                mvf.createLiteral("a value"),
+                TestUtil.asIri("http://example.org/context"));
+
+        serializeTest(s);
+    }
+
+}

--- a/core/src/test/java/info/rmapproject/core/SerializationAssertions.java
+++ b/core/src/test/java/info/rmapproject/core/SerializationAssertions.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.core;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Assertions relating to object serialization shared between the RMap core module and the integration module.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class SerializationAssertions {
+
+    /**
+     * Serializes the supplied object using {@link ObjectOutputStream} and attempts to read it back in using
+     * {@link ObjectInputStream}.  The {@code equals(Object)} method is used to compare the results.
+     *
+     * @param expectedObject the object to serialize, and used for comparison against the round-tripped object
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    public static void serializeTest(Object expectedObject) throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+        try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(expectedObject);
+        }
+
+        Object actualObject = null;
+
+        try (ByteArrayInputStream bin = new ByteArrayInputStream(bos.toByteArray());
+             ObjectInputStream ois = new ObjectInputStream(bin)) {
+            actualObject = ois.readObject();
+        }
+
+        assertNotNull(actualObject);
+        assertEquals(expectedObject, actualObject);
+    }
+}

--- a/core/src/test/java/info/rmapproject/core/TestUtil.java
+++ b/core/src/test/java/info/rmapproject/core/TestUtil.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.core;
+
+import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.RMapLiteral;
+import info.rmapproject.core.model.impl.openrdf.ORAdapter;
+import org.openrdf.model.IRI;
+import org.openrdf.model.Literal;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static info.rmapproject.core.model.impl.openrdf.ORAdapter.openRdfIri2RMapIri;
+import static info.rmapproject.core.model.impl.openrdf.ORAdapter.uri2OpenRdfIri;
+import static java.net.URI.create;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Utility methods that support tests.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class TestUtil {
+
+    public static final AtomicInteger COUNTER = new AtomicInteger();
+
+    /**
+     * Joins the supplied strings.
+     *
+     * @param joinWith the string used to join the strings
+     * @param objects the strings to be joined
+     * @return the joined strings
+     */
+    public static String join(String joinWith, String... objects) {
+        return join(joinWith, false, false, objects);
+    }
+
+    /**
+     * Joins the supplied strings, optionally prefixing and postfixing the returned string.
+     *
+     * @param joinWith the string used to join the strings
+     * @param prefix prefix the returned string with {@code joinWith}
+     * @param postfix postfix the returned string with {@code joinWith}
+     * @param objects the strings to be joined
+     * @return the joined strings
+     */
+    public static String join(String joinWith, boolean prefix, boolean postfix, String... objects) {
+        StringBuilder sb = null;
+        if (prefix) {
+            sb = new StringBuilder(joinWith);
+        } else {
+            sb = new StringBuilder();
+        }
+
+        for (int i = 0; i < objects.length; ) {
+            sb.append(objects[i]);
+            if (i++ < objects.length) {
+                sb.append(joinWith);
+            }
+        }
+
+        if (postfix) {
+            sb.append(joinWith);
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Creates a unique file under {@code java.io.tmpdir} and returns the {@link File#getCanonicalFile() canonical}
+     * {@code File}.  The file is deleted on exit.  This methodology
+     * <ol>
+     *   <li>guarantees a unique file name,</li>
+     *   <li>doesn't clutter the filesystem with test-related directories or files,</li>
+     *   <li>returns an absolute path (important for relative volume binding strings),
+     *   <li>and returns a canonical file name.</li>
+     * </ol>
+     *
+     * @param nameHint a string used to help create the temporary file name, may be {@code null}
+     * @return the temporary file
+     */
+    public static File createTmpFile(String nameHint) {
+        return createTmpFile(nameHint, TMP_FILE_PRESERVE_MODE.DELETE_ON_EXIT);
+    }
+
+    /**
+     * Creates a unique file under {@code java.io.tmpdir} and returns the {@link File#getCanonicalFile() canonical}
+     * {@code File}.  The optional {@code preserveMode} parameter dictates who is responsible for deleting the created
+     * file, and when.  This methodology
+     * <ol>
+     *   <li>guarantees a unique file name,</li>
+     *   <li>doesn't clutter the filesystem with test-related directories or files,</li>
+     *   <li>returns an absolute path (important for relative volume binding strings),
+     *   <li>and returns a canonical file name.</li>
+     * </ol>
+     *
+     * @param nameHint a string used to help create the temporary file name, may be {@code null}
+     * @param preserveMode mechanism for handling the clean up of files created by this method, may be {@code null}
+     *                     which is equivalent to {@link TMP_FILE_PRESERVE_MODE#DELETE_ON_EXIT}
+     * @return the absolute temporary file, which may not exist depending on the {@code preserveMode}
+     */
+    public static File createTmpFile(String nameHint, TMP_FILE_PRESERVE_MODE preserveMode) {
+        try {
+            File tmpFile = File.createTempFile(nameHint, ".tmp");
+            assertTrue("The created temporary file " + tmpFile + " is not absolute!", tmpFile.isAbsolute());
+            if (preserveMode != null) {
+                switch (preserveMode) {
+                    case DELETE_IMMEDIATELY:
+                        assertTrue("Unable to delete temporary file " + tmpFile, tmpFile.delete());
+                        break;
+                    case DELETE_ON_EXIT:
+                        tmpFile.deleteOnExit();
+                        break;
+                    // PRESERVE is a no-op
+                }
+            } else {
+                // default when preserveMode is null
+                tmpFile.deleteOnExit();
+            }
+            return tmpFile.getCanonicalFile();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to create or canonicalize temporary directory");
+        }
+    }
+
+    public static IRI asIri(String uri) {
+        return uri2OpenRdfIri(create(uri));
+    }
+
+    public static RMapIri asRmapIri(String uri) {
+        return openRdfIri2RMapIri(asIri(uri));
+    }
+
+    public static RMapLiteral asRmapLiteral(String literalValue) {
+        return new RMapLiteral(literalValue);
+    }
+
+    public static Literal asLiteral(String literalValue) {
+        return ORAdapter.getValueFactory().createLiteral(literalValue);
+    }
+
+    public static int count() {
+        return COUNTER.getAndIncrement();
+    }
+
+    /**
+     * Modes for handling the removal of created temporary files
+     */
+    public enum TMP_FILE_PRESERVE_MODE {
+
+        /**
+         * Deletes the created file immediately
+         */
+        DELETE_IMMEDIATELY,
+
+        /**
+         * Asks the JVM to delete the file on exit
+         */
+        DELETE_ON_EXIT,
+
+        /**
+         * Preserve the file, do not delete it.  The caller is responsible for clean up.
+         */
+        PRESERVE
+    };
+
+}

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -39,6 +39,15 @@
         </dependency>
 
         <dependency>
+            <groupId>info.rmapproject</groupId>
+            <artifactId>rmap-core</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
             <groupId>org.openrdf.sesame</groupId>
             <artifactId>sesame-http-server</artifactId>
             <type>war</type>

--- a/integration/src/main/resources/integration-triplestore.xml
+++ b/integration/src/main/resources/integration-triplestore.xml
@@ -19,19 +19,19 @@
       <property name="triplestoreInitializer" ref="integrationTriplestoreInitializer"/>
     </bean>
 
-    <bean id="integrationTriplestoreInitializer" class="info.rmapproject.spring.triplestore.support.SpringTriplestoreInitializer">
-      <property name="triplestoreManager">
-        <bean class="info.rmapproject.spring.triplestore.support.SesameTriplestoreManager">
-          <property name="workbenchBaseUrl" value="${sesamehttp.workbench.url}"/>
-          <property name="repositoryBaseUrl" value="${sesamehttp.repository.url}"/>
-          <property name="defaultName" value="${sesamehttp.repository.name}"/>
-          <property name="httpClient">
-            <bean class="okhttp3.OkHttpClient"/>
-          </property>
-        </bean>
+    <bean id="triplestoreManager" class="info.rmapproject.spring.triplestore.support.SesameTriplestoreManager">
+      <property name="workbenchBaseUrl" value="${sesamehttp.workbench.url}"/>
+      <property name="repositoryBaseUrl" value="${sesamehttp.repository.url}"/>
+      <property name="defaultName" value="${sesamehttp.repository.name}"/>
+      <property name="httpClient">
+        <bean class="okhttp3.OkHttpClient"/>
       </property>
+    </bean>
+
+    <bean id="integrationTriplestoreInitializer" class="info.rmapproject.spring.triplestore.support.SpringTriplestoreInitializer">
+      <property name="triplestoreManager" ref="triplestoreManager"/>
       <property name="initializeEnabled" value="true"/>
-      <property name="destroyEnabled" value="false"/>
+      <property name="destroyEnabled" value="true"/>
     </bean>
 
   </beans>

--- a/integration/src/test/java/info/rmapproject/integration/ManagerObjectSerializationIT.java
+++ b/integration/src/test/java/info/rmapproject/integration/ManagerObjectSerializationIT.java
@@ -1,0 +1,260 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.integration;
+
+import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.RMapLiteral;
+import info.rmapproject.core.model.agent.RMapAgent;
+import info.rmapproject.core.model.event.RMapEvent;
+import info.rmapproject.core.model.event.RMapEventTargetType;
+import info.rmapproject.core.model.impl.openrdf.ORAdapter;
+import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
+import info.rmapproject.core.model.impl.openrdf.ORMapDiSCO;
+import info.rmapproject.core.model.impl.openrdf.ORMapEvent;
+import info.rmapproject.core.model.impl.openrdf.ORMapEventCreation;
+import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.rmapservice.RMapService;
+import info.rmapproject.core.rmapservice.impl.openrdf.ORMapAgentMgr;
+import info.rmapproject.core.rmapservice.impl.openrdf.ORMapDiSCOMgr;
+import info.rmapproject.core.rmapservice.impl.openrdf.ORMapEventMgr;
+import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
+import info.rmapproject.spring.triplestore.support.TriplestoreManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openrdf.model.IRI;
+import org.openrdf.model.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Calendar;
+import java.util.List;
+
+import static info.rmapproject.core.SerializationAssertions.serializeTest;
+import static info.rmapproject.core.TestUtil.asIri;
+import static info.rmapproject.core.TestUtil.asLiteral;
+import static info.rmapproject.core.TestUtil.asRmapIri;
+import static info.rmapproject.core.TestUtil.count;
+import static info.rmapproject.testdata.service.TestConstants.SYSAGENT_AUTH_ID;
+import static info.rmapproject.testdata.service.TestConstants.SYSAGENT_ID;
+import static info.rmapproject.testdata.service.TestConstants.SYSAGENT_ID_PROVIDER;
+import static info.rmapproject.testdata.service.TestConstants.SYSAGENT_KEY;
+import static info.rmapproject.testdata.service.TestConstants.SYSAGENT_NAME;
+import static java.net.URI.create;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * The various RMap service interfaces hide various implementations, from the OpenRDF ValueFactory used to create
+ * statements, to the myriad constructors and objects used to construct RMap domain objects.  This integration test
+ * does a first pass at insuring that the objects returned by the various {@code create*(...)} of these interfaces
+ * return an object graph that can be (de)serialized by the JVM {@link java.io.ObjectOutputStream} and {@link
+ * java.io.ObjectInputStream}.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath*:/spring-rmapcore-context.xml")
+@ActiveProfiles({"integration-triplestore", "integration-db", "inmemory-idservice"})
+public class ManagerObjectSerializationIT {
+
+    private static final IRI DISCO_IRI = asIri("http://example.org/disco/1");
+
+    private static final RMapIri CREATOR_IRI = asRmapIri("http://example.org/creator/1");
+
+    private static final List<URI> AGGREGATED_RESOURCES = singletonList(create("http://example.org/resources/1"));
+
+    @Autowired
+    private RMapService rMapService;
+
+    @Autowired
+    private ORMapDiSCOMgr discoMgr;
+
+    @Autowired
+    private ORMapEventMgr eventMgr;
+
+    @Autowired
+    private ORMapAgentMgr agentMgr;
+
+    @Autowired
+    private SesameTriplestore triplestore;
+
+    @Autowired
+    private TriplestoreManager tsMgr;
+
+    private RMapAgent systemAgent = new ORMapAgent(asIri(SYSAGENT_ID),
+                                        asIri(SYSAGENT_ID_PROVIDER),
+                                        asIri(SYSAGENT_AUTH_ID),
+                                        asLiteral(SYSAGENT_NAME));
+
+    private RMapRequestAgent requestAgent = new RMapRequestAgent(create(SYSAGENT_ID), create(SYSAGENT_KEY));
+
+    @Before
+    public void setUp() throws Exception {
+        try {
+            tsMgr.clearTriplestore();
+        } catch (Exception e) {
+            // don't care
+        }
+
+        rMapService.createAgent(systemAgent, requestAgent);
+
+        serializeTest(requestAgent);
+        serializeTest(systemAgent);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        tsMgr.clearTriplestore();
+    }
+
+    @Test
+    public void discoManagerCreateSerialization() throws Exception {
+        ORMapDiSCO disco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
+        serializeTest(disco);
+
+        RMapEvent event = discoMgr.createDiSCO(disco, requestAgent, triplestore);
+
+        assertNotNull(event);
+        serializeTest(event);
+    }
+
+    @Test
+    public void discoManagerTombstoneSerialization() throws Exception {
+        ORMapDiSCO disco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
+        discoMgr.createDiSCO(disco, requestAgent, triplestore);
+
+        RMapEvent event = discoMgr.tombstoneDiSCO(DISCO_IRI, requestAgent, triplestore);
+
+        assertNotNull(event);
+        serializeTest(event);
+    }
+
+    @Test
+    public void discoManagerUpdateSerialization() throws Exception {
+        ORMapDiSCO originalDisco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
+        discoMgr.createDiSCO(originalDisco, requestAgent, triplestore);
+
+        ORMapDiSCO newDisco = new ORMapDiSCO(
+                asIri("http://example.org/disco/2"), CREATOR_IRI, AGGREGATED_RESOURCES);
+
+        doUpdateAndPerformAssertions(DISCO_IRI, newDisco, false);
+    }
+
+    @Test
+    public void discoManagerInactivateSerialization() throws Exception {
+        ORMapDiSCO originalDisco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
+        discoMgr.createDiSCO(originalDisco, requestAgent, triplestore);
+
+        ORMapDiSCO newDisco = new ORMapDiSCO(
+                asIri("http://example.org/disco/2"), CREATOR_IRI, AGGREGATED_RESOURCES);
+
+        doUpdateAndPerformAssertions(DISCO_IRI, newDisco, true);
+    }
+
+    @Test
+    public void eventManagerCreateSerialization() throws Exception {
+        IRI eventIri = asIri("http://example.com/event/1");
+        RMapEventTargetType type = RMapEventTargetType.DISCO;
+        RMapLiteral desc = new RMapLiteral("Creation Event Description");
+        List<RMapIri> created = singletonList(asRmapIri("http://example.org/disco/1"));
+
+        ORMapEventCreation event = new ORMapEventCreation(eventIri, requestAgent, type, desc, created);
+        Calendar endTime = Calendar.getInstance();
+        endTime.add(Calendar.MILLISECOND, 500);
+        event.setEndTime(endTime.getTime());
+        serializeTest(event);
+
+        IRI iri = eventMgr.createEvent(event, triplestore);
+
+        assertNotNull(iri);
+        serializeTest(iri);
+    }
+
+    @Test
+    public void agentManagerSerialization() throws Exception {
+        IRI agentIri = asIri("http://example.com/agent/" + count());
+        IRI providerIri = asIri("http://example.com/provider/" + count());
+        IRI authIri = asIri("http://example.com/authid/" + count());
+        Value agentName = ORAdapter.getValueFactory().createLiteral("An Agent");
+
+        ORMapAgent agent = new ORMapAgent(agentIri, providerIri, authIri, agentName);
+        serializeTest(agent);
+
+        ORMapEvent event = agentMgr.createAgent(agent, requestAgent, triplestore);
+        assertNotNull(event);
+        serializeTest(event);
+    }
+
+    @Test
+    public void rmapServiceCreateDisco() throws Exception {
+        ORMapDiSCO disco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
+        RMapEvent event = rMapService.createDiSCO(disco, requestAgent);
+
+        assertNotNull(event);
+        serializeTest(event);
+    }
+
+    @Test
+    public void rmapServiceCreateAgentOne() throws Exception {
+        RMapEvent event = rMapService.createAgent("Agent Name",
+                create("http://example.org/idp"), create("http://example.org/key"));
+
+        assertNotNull(event);
+        serializeTest(event);
+    }
+
+    @Test
+    public void rmapServiceCreateAgentTwo() throws Exception {
+        RMapEvent event = rMapService.createAgent(create("http://example.org/agent/id"), "Agent Name",
+                create("http://example.org/idp"), create("http://example.org/key"), requestAgent);
+
+        assertNotNull(event);
+        serializeTest(event);
+    }
+
+
+    @Test
+    public void rmapServiceCreateAgentThree() throws Exception {
+        IRI agentIri = asIri("http://example.com/agent/" + count());
+        IRI providerIri = asIri("http://example.com/provider/" + count());
+        IRI authIri = asIri("http://example.com/authid/" + count());
+        Value agentName = ORAdapter.getValueFactory().createLiteral("An Agent");
+        ORMapAgent agent = new ORMapAgent(agentIri, providerIri, authIri, agentName);
+
+        RMapEvent event = rMapService.createAgent(agent, requestAgent);
+
+        assertNotNull(event);
+        serializeTest(event);
+    }
+
+    private void doUpdateAndPerformAssertions(IRI discoIri, ORMapDiSCO newDisco, boolean inactivate)
+            throws IOException, ClassNotFoundException {
+        RMapEvent event = discoMgr.updateDiSCO(discoIri, newDisco, requestAgent, inactivate, triplestore);
+
+        assertNotNull(event);
+        serializeTest(event);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,18 @@
                     <artifactId>beanshell-maven-plugin</artifactId>
                     <version>1.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
- add hashCode() and equals(Object) to support unit tests; these methods are value-based: instances are compared on a field-by-field basis.  The equals implementation used will break the contract of the equals method due to subclassing, but that is an acceptable compromise. 
- add toString() methods where they were not implemented previously, to support comparison during unit testing 
- add 'serialVersionUID' and `implements java.io.Serializable` to the domain objects 
- include unit and integration tests which provide smoke tests of round tripping (object -> bytes -> object) domain object graphs. 
- share test utility classes from the core module to integration module


