### PR TITLE
Add missing serialVersionUID field to RMap domain objects

### DIFF
--- a/core/src/main/java/info/rmapproject/core/model/RMapBlankNode.java
+++ b/core/src/main/java/info/rmapproject/core/model/RMapBlankNode.java
@@ -27,6 +27,8 @@ package info.rmapproject.core.model;
  */
 public class RMapBlankNode extends RMapResource {
 
+	private static final long serialVersionUID = 1L;
+
 	/** The blank node id. */
 	protected String id;
 

--- a/core/src/main/java/info/rmapproject/core/model/RMapIri.java
+++ b/core/src/main/java/info/rmapproject/core/model/RMapIri.java
@@ -30,6 +30,8 @@ import java.net.URI;
  */
 public class RMapIri extends RMapResource  {
 
+	private static final long serialVersionUID = 1L;
+
 	/** The IRI. */
 	URI iri;
 	

--- a/core/src/main/java/info/rmapproject/core/model/RMapResource.java
+++ b/core/src/main/java/info/rmapproject/core/model/RMapResource.java
@@ -33,7 +33,7 @@ import java.io.Serializable;
  */
 public abstract class RMapResource implements RMapValue, Serializable {
 
-	private static long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Instantiates a new RMap resource.

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapAgent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapAgent.java
@@ -40,6 +40,8 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  * @author khanson, smorrissey
  */
 public class ORMapAgent extends ORMapObject implements RMapAgent {
+
+	private static final long serialVersionUID = 1L;
 	
 	/** The Agent's name stmt. */
 	protected Statement nameStmt;

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapDiSCO.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapDiSCO.java
@@ -56,6 +56,9 @@ import info.rmapproject.core.vocabulary.impl.openrdf.PROV;
  *
  */
 public class ORMapDiSCO extends ORMapObject implements RMapDiSCO {
+
+	private static final long serialVersionUID = 1L;
+
 	/**
 	 * 1 or more Statements of the form discoID RMAP.AGGREGATES  Resource
 	 * Context will be discoID

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
@@ -54,6 +54,8 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  *
  */
 public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
+
+	private static final long serialVersionUID = 1L;
 	
 	/** The event type stmt. */
 	protected Statement eventTypeStmt;  // will be set by constructor of concrete Event class

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreation.java
@@ -43,6 +43,8 @@ import org.openrdf.model.IRI;
  */
 public class ORMapEventCreation extends ORMapEventWithNewObjects implements RMapEventCreation {
 
+	private static final long serialVersionUID = 1L;
+
 	/**
 	 * Instantiates a new RMap Creation Event.
 	 *

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
@@ -43,6 +43,8 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  */
 public class ORMapEventDeletion extends ORMapEvent implements RMapEventDeletion {
 
+	private static final long serialVersionUID = 1L;
+
 	/** The list of Statements containing deleted object IDs. */
 	protected List<Statement> deletedObjects;
 	

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
@@ -47,6 +47,8 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 public class ORMapEventDerivation extends ORMapEventWithNewObjects implements
 		RMapEventDerivation {
 
+	private static final long serialVersionUID = 1L;
+
 	/** The statement containing the source object ID. */
 	protected Statement sourceObjectStatement;
 	

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
@@ -44,7 +44,9 @@ import org.openrdf.model.Statement;
  */
 public class ORMapEventInactivation extends ORMapEvent implements
 		RMapEventInactivation {
-	
+
+	private static final long serialVersionUID = 1L;
+
 	/** The statement that defines the inactivated object. */
 	protected Statement inactivatedObjectStatement;
 	

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
@@ -43,6 +43,8 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 public class ORMapEventTombstone extends ORMapEvent implements
 		RMapEventTombstone {
 
+	private static final long serialVersionUID = 1L;
+
 	/** The statement that defines the tombstoned object. */
 	protected Statement tombstoned;
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
@@ -46,6 +46,8 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  *
  */
 public class ORMapEventUpdate extends ORMapEventWithNewObjects implements RMapEventUpdate {
+
+	private static final long serialVersionUID = 1L;
 	
 	/** The statement containing the derived object id. */
 	protected Statement derivationStatement;

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
@@ -41,6 +41,8 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  */
 public class ORMapEventUpdateWithReplace extends ORMapEvent implements RMapEventUpdateWithReplace {
 
+	private static final long serialVersionUID = 1L;
+
 	/** The statement containing the IRI of the updated object. */
 	protected Statement updatedObjectIdStmt;
 	

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
@@ -46,7 +46,9 @@ import info.rmapproject.core.vocabulary.impl.openrdf.PROV;
  */
 public abstract class ORMapEventWithNewObjects extends ORMapEvent implements
 		RMapEventWithNewObjects {
-	
+
+	private static final long serialVersionUID = 1L;
+
 	/** List of statements that have references to IRIs of created objects. */
 	protected List<Statement> createdObjects;
 


### PR DESCRIPTION
Insure each class in the RMap domain hierarchy immediately declares (i.e. not via inheritance) a "serialVersionUID" for java.io.Serializable.