### PR TITLE
Resolve connection hang in webapp

### DIFF
--- a/api/src/main/java/info/rmapproject/api/auth/ApiUserServiceImpl.java
+++ b/api/src/main/java/info/rmapproject/api/auth/ApiUserServiceImpl.java
@@ -65,7 +65,7 @@ public class ApiUserServiceImpl implements ApiUserService {
 	public AuthorizationPolicy getCurrentAuthPolicy() throws RMapApiException {
 		AuthorizationPolicy authorizationPolicy = null;
 		Message message = JAXRSUtils.getCurrentMessage();
-		authorizationPolicy = (AuthorizationPolicy)message.get(AuthorizationPolicy.class);
+		authorizationPolicy = message.get(AuthorizationPolicy.class);
 	    if (authorizationPolicy == null) {
 	        throw new RMapApiException(ErrorCode.ER_COULD_NOT_RETRIEVE_AUTHPOLICY);
 	        }

--- a/api/src/main/java/info/rmapproject/api/responsemgr/AgentResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/AgentResponseManager.java
@@ -195,7 +195,6 @@ public class AgentResponseManager extends ResponseManager {
 			throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;
@@ -265,7 +264,6 @@ public class AgentResponseManager extends ResponseManager {
 			throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;
@@ -409,7 +407,6 @@ public class AgentResponseManager extends ResponseManager {
     		throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
     	return response;

--- a/api/src/main/java/info/rmapproject/api/responsemgr/DiscoResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/DiscoResponseManager.java
@@ -237,7 +237,6 @@ public class DiscoResponseManager extends ResponseManager {
 			throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		
@@ -332,7 +331,6 @@ public class DiscoResponseManager extends ResponseManager {
 			throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;		
@@ -403,7 +401,6 @@ public class DiscoResponseManager extends ResponseManager {
 			throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;	
@@ -488,7 +485,6 @@ public class DiscoResponseManager extends ResponseManager {
 			throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;	
@@ -608,7 +604,6 @@ public class DiscoResponseManager extends ResponseManager {
 			throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 	return response;	
@@ -734,7 +729,6 @@ public class DiscoResponseManager extends ResponseManager {
 			throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 	return response;		
@@ -822,7 +816,6 @@ public class DiscoResponseManager extends ResponseManager {
     		throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
     	return response;
@@ -905,7 +898,6 @@ public class DiscoResponseManager extends ResponseManager {
     		throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
     	return response;
@@ -980,7 +972,6 @@ public class DiscoResponseManager extends ResponseManager {
     		throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
     	return response;

--- a/api/src/main/java/info/rmapproject/api/responsemgr/EventResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/EventResponseManager.java
@@ -184,7 +184,6 @@ public class EventResponseManager extends ResponseManager {
         	throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;
@@ -283,7 +282,6 @@ public class EventResponseManager extends ResponseManager {
     		throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
     	return response;

--- a/api/src/main/java/info/rmapproject/api/responsemgr/ResourceResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/ResourceResponseManager.java
@@ -239,7 +239,6 @@ public class ResourceResponseManager extends ResponseManager {
         	throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
     	return response;
@@ -336,7 +335,6 @@ public class ResourceResponseManager extends ResponseManager {
         	throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService != null) rmapService.closeConnection();
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;

--- a/api/src/main/java/info/rmapproject/api/responsemgr/StatementResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/StatementResponseManager.java
@@ -224,7 +224,6 @@ public class StatementResponseManager extends ResponseManager {
         	throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService!=null){rmapService.closeConnection();}
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;
@@ -328,7 +327,6 @@ public class StatementResponseManager extends ResponseManager {
         	throw RMapApiException.wrap(ex,ErrorCode.ER_UNKNOWN_SYSTEM_ERROR);
 		}
 		finally{
-			if (rmapService!=null){rmapService.closeConnection();}
 			if (!reqSuccessful && response!=null) response.close();
 		}
 		return response;

--- a/auth/src/main/java/info/rmapproject/auth/service/UserRMapAgentServiceImpl.java
+++ b/auth/src/main/java/info/rmapproject/auth/service/UserRMapAgentServiceImpl.java
@@ -128,11 +128,7 @@ public class UserRMapAgentServiceImpl {
 
 		} catch (URISyntaxException | RMapException | RMapDefectiveArgumentException ex) {
 			throw new RMapAuthException(ErrorCode.ER_USER_AGENT_NOT_FORMED_IN_DB.getMessage(),ex.getCause());
-		} finally {
-			if (rmapService!=null){
-				rmapService.closeConnection();
-			}
-		}
+		} 
 		
 		return event;
 	}

--- a/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
@@ -513,13 +513,5 @@ public interface RMapService {
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
 	public boolean isEventId(URI id) throws RMapException, RMapDefectiveArgumentException;
-	
-	
-	/**
-	 * Closes triplestore connection if it is still open.
-	 *
-	 * @throws RMapException an RMapException
-	 */
-    public void closeConnection() throws RMapException;
 
 }

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapObjectMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapObjectMgr.java
@@ -79,16 +79,15 @@ public abstract class ORMapObjectMgr {
 		if (ts==null || id==null || typeIRI==null){
 			throw new RMapException("Null parameter passed");
 		}
-		boolean isCorrectType = false;
 		try {
-			Set<Statement> stmts = ts.getStatements(id, RDF.TYPE, typeIRI, id);
-			if (stmts != null && stmts.size()>0){
-				isCorrectType = true;
+			if (ts.getConnection().size(id)>0) {
+				return ts.getConnection().hasStatement(id, RDF.TYPE, typeIRI, false, id);
+			} else {
+				return false;
 			}
 		} catch (Exception e) {
 			throw new RMapException ("Exception thrown searching for object " + id.stringValue(), e);
 		}		
-		return isCorrectType;	
 	}
 
 	/**

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
@@ -75,35 +75,27 @@ import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplest
 public class ORMapService implements RMapService {
 
 	/** Instance of the RMap Resource Manager */
-	@Autowired
 	private ORMapResourceMgr resourcemgr;
 
 	/** Instance of the RMap DiSCO Manager */
-	@Autowired
 	private ORMapDiSCOMgr discomgr;
 
 	/** Instance of the RMap Agent Manager */
-	@Autowired
 	private ORMapAgentMgr agentmgr;
 
 	/** Instance of the RMap Statement Manager */
-	@Autowired
 	private ORMapStatementMgr statementmgr;
 
 	/** Instance of the RMap Event Manager */
-	@Autowired
 	private ORMapEventMgr eventmgr;
 	
 	/** An instance of the sesame triplestore for database changes.
 	 * It is declared in the ORMapService so that it can be passed to multiple functions
 	 * across a single interaction */
-	@Autowired
 	private SesameTriplestore triplestore;
 
-	@Autowired
 	private RMapSearchParamsFactory paramsFactory;
 
-	@Autowired
 	private IdService idService;
 
 	/**
@@ -124,6 +116,7 @@ public class ORMapService implements RMapService {
 						ORMapStatementMgr statementmgr,
 						ORMapEventMgr eventmgr,
 						SesameTriplestore triplestore,
+						RMapSearchParamsFactory paramsFactory,
 						IdService idService) {
 		this.resourcemgr = resourcemgr;
 		this.discomgr = discomgr;
@@ -131,6 +124,7 @@ public class ORMapService implements RMapService {
 		this.statementmgr = statementmgr;
 		this.eventmgr = eventmgr;
 		this.triplestore = triplestore;
+		this.paramsFactory = paramsFactory;
 		this.idService = idService;
 	}
 	

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
@@ -128,14 +128,16 @@ public class ORMapService implements RMapService {
 		this.idService = idService;
 	}
 	
-
-	/* (non-Javadoc)
-	 * @see info.rmapproject.core.rmapservice.RMapService#closeConnection()
+	
+	/**
+	 * Closes triplestore connection if still open. Do this after each set of queries to triplestore
+	 * @throws RMapException
 	 */
-	@Override
 	public void closeConnection() throws RMapException {
 		try {
-            triplestore.closeConnection();
+			if (triplestore!=null) {
+				triplestore.closeConnection();
+			}
 		}
 		catch(Exception e)  {
             throw new RMapException("Could not close connection");
@@ -148,7 +150,11 @@ public class ORMapService implements RMapService {
 	@Override
 	public ResultBatch<RMapTriple> getResourceRelatedTriples(URI uri, RMapSearchParams params)
 			throws RMapException, RMapDefectiveArgumentException {
-		return getResourceRelatedTriples(uri, null, params);
+		try {
+			return getResourceRelatedTriples(uri, null, params);
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	
@@ -159,41 +165,46 @@ public class ORMapService implements RMapService {
 	@Override
 	public ResultBatch<RMapTriple> getResourceRelatedTriples(URI uri, URI context, RMapSearchParams params)
 			throws RMapException, RMapDefectiveArgumentException {
-		if (uri==null){
-			throw new RMapDefectiveArgumentException("Null URI");
+		try {
+			if (uri==null){
+				throw new RMapDefectiveArgumentException("Null URI");
+			}
+			if (params==null){
+				params = paramsFactory.newInstance();
+			}
+			org.openrdf.model.IRI mIri = uri2OpenRdfIri(uri);
+			org.openrdf.model.IRI mContextIri = uri2OpenRdfIri(context);
+					
+			List<Statement> stmts;
+			
+			params.setCheckNext(true);
+			
+			if (context!=null){
+				stmts = resourcemgr.getRelatedTriples(mIri, mContextIri, params, triplestore);
+			} else {
+				stmts = resourcemgr.getRelatedTriples(mIri, params, triplestore); 
+			}
+			
+			List<RMapTriple> triples = new ArrayList<RMapTriple>();
+			for (Statement stmt:stmts){
+				RMapTriple triple = ORAdapter.openRdfStatement2RMapTriple(stmt);
+				triples.add(triple);
+			}
+			
+			//if records go over limit, there are more records to be retrieved
+			boolean hasNext = (triples.size()>params.getLimit());
+			//remove the extra record if there is one
+			if (hasNext){
+				triples.remove(triples.size()-1);					
+			}
+			
+			ResultBatch<RMapTriple> resultbatch = new ResultBatchImpl<RMapTriple>(triples, hasNext, params.getOffset()+1);
+			
+			return resultbatch;
+			
+		} finally {
+			closeConnection();
 		}
-		if (params==null){
-			params = paramsFactory.newInstance();
-		}
-		org.openrdf.model.IRI mIri = uri2OpenRdfIri(uri);
-		org.openrdf.model.IRI mContextIri = uri2OpenRdfIri(context);
-				
-		List<Statement> stmts;
-		
-		params.setCheckNext(true);
-		
-		if (context!=null){
-			stmts = resourcemgr.getRelatedTriples(mIri, mContextIri, params, triplestore);
-		} else {
-			stmts = resourcemgr.getRelatedTriples(mIri, params, triplestore); 
-		}
-		
-		List<RMapTriple> triples = new ArrayList<RMapTriple>();
-		for (Statement stmt:stmts){
-			RMapTriple triple = ORAdapter.openRdfStatement2RMapTriple(stmt);
-			triples.add(triple);
-		}
-		
-		//if records go over limit, there are more records to be retrieved
-		boolean hasNext = (triples.size()>params.getLimit());
-		//remove the extra record if there is one
-		if (hasNext){
-			triples.remove(triples.size()-1);					
-		}
-		
-		ResultBatch<RMapTriple> resultbatch = new ResultBatchImpl<RMapTriple>(triples, hasNext, params.getOffset()+1);
-		
-		return resultbatch;
 	}
 	
 	
@@ -203,8 +214,12 @@ public class ORMapService implements RMapService {
 	@Override
 	public ResultBatch<URI> getResourceRelatedEvents (URI uri, RMapSearchParams params)
 			throws RMapException, RMapDefectiveArgumentException {
-		UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> resourcemgr.getResourceRelatedEvents(iri, prms, triplestore);
-		return getUriBatch(uri,params,uriBatchReq);
+		try {
+			UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> resourcemgr.getResourceRelatedEvents(iri, prms, triplestore);
+			return getUriBatch(uri,params,uriBatchReq);
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -213,8 +228,12 @@ public class ORMapService implements RMapService {
 	@Override
 	public ResultBatch<URI> getResourceRelatedDiSCOs (URI uri, RMapSearchParams params)
 			throws RMapException, RMapDefectiveArgumentException {
-		UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> resourcemgr.getResourceRelatedDiSCOS(iri, prms, triplestore);
-		return getUriBatch(uri,params,uriBatchReq);
+		try {
+			UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> resourcemgr.getResourceRelatedDiSCOS(iri, prms, triplestore);
+			return getUriBatch(uri,params,uriBatchReq);
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -223,8 +242,12 @@ public class ORMapService implements RMapService {
 	@Override
 	public ResultBatch<URI> getResourceAssertingAgents (URI uri, RMapSearchParams params)
 			throws RMapException, RMapDefectiveArgumentException {
-		UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> resourcemgr.getResourceAssertingAgents(iri, prms, triplestore);
-		return getUriBatch(uri,params,uriBatchReq);
+		try {
+			UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> resourcemgr.getResourceAssertingAgents(iri, prms, triplestore);
+			return getUriBatch(uri,params,uriBatchReq);
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -241,14 +264,19 @@ public class ORMapService implements RMapService {
 		}
 		org.openrdf.model.IRI resourceIri = uri2OpenRdfIri(resourceUri);
 		org.openrdf.model.IRI contextIri = uri2OpenRdfIri(discoUri);
-		
-		List<org.openrdf.model.IRI> uris = resourcemgr.getResourceRdfTypes(resourceIri, contextIri, triplestore);
-		if (uris == null){
-			return null;
+
+		try {
+			List<org.openrdf.model.IRI> uris = resourcemgr.getResourceRdfTypes(resourceIri, contextIri, triplestore);
+			if (uris == null){
+				return null;
+			}
+			List<URI> returnSet = ORAdapter.openRdfIriList2UriList(uris);
+			return returnSet;
+		}
+		finally {
+			closeConnection();
 		}
 
-		List<URI> returnSet = ORAdapter.openRdfIriList2UriList(uris);
-		return returnSet;
 	}
 
 	/* (non-Javadoc)
@@ -265,15 +293,19 @@ public class ORMapService implements RMapService {
 		}
 		IRI rUri = uri2OpenRdfIri(resourceUri);
 		Map<URI, Set<URI>> map = null;
-		Map<IRI, Set<IRI>> typesMap = resourcemgr.getResourceRdfTypesAllContexts(rUri, params, triplestore);
-		if (typesMap != null && typesMap.keySet().size()>0){
-			map = new HashMap<URI, Set<URI>>();
-			for (IRI uri : typesMap.keySet()){
-				Set<IRI> types = typesMap.get(uri);
-				URI key = ORAdapter.openRdfIri2URI(uri);
-				Set<URI> values = ORAdapter.openRdfIriSet2UriSet(types);
-				map.put(key, values);
-			}				
+		try {
+			Map<IRI, Set<IRI>> typesMap = resourcemgr.getResourceRdfTypesAllContexts(rUri, params, triplestore);
+			if (typesMap != null && typesMap.keySet().size()>0){
+				map = new HashMap<URI, Set<URI>>();
+				for (IRI uri : typesMap.keySet()){
+					Set<IRI> types = typesMap.get(uri);
+					URI key = ORAdapter.openRdfIri2URI(uri);
+					Set<URI> values = ORAdapter.openRdfIriSet2UriSet(types);
+					map.put(key, values);
+				}				
+			}
+		} finally {
+			closeConnection();
 		}
 		return map;
 	}
@@ -307,8 +339,12 @@ public class ORMapService implements RMapService {
 		if (discoID == null){
 			throw new RMapDefectiveArgumentException("Null DiSCO id provided");
 		}
-		ORMapDiSCO disco = discomgr.readDiSCO(uri2OpenRdfIri(discoID), triplestore);
-		return disco;
+		try {
+			ORMapDiSCO disco = discomgr.readDiSCO(uri2OpenRdfIri(discoID), triplestore);
+			return disco;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -326,8 +362,12 @@ public class ORMapService implements RMapService {
 		if (!(disco instanceof ORMapDiSCO)){
 			throw new RMapDefectiveArgumentException("disco not instance of ORMapDiSCO");
 		}
-		RMapEvent createEvent = discomgr.createDiSCO((ORMapDiSCO)disco, requestAgent, triplestore);
-		return createEvent;
+		try {
+			RMapEvent createEvent = discomgr.createDiSCO((ORMapDiSCO)disco, requestAgent, triplestore);
+			return createEvent;			
+		} finally {
+			closeConnection();
+		}
 	}
 
 
@@ -339,8 +379,12 @@ public class ORMapService implements RMapService {
 		if (discoId ==null){
 			throw new RMapDefectiveArgumentException("Null DiSCO id provided");
 		}
-		RMapStatus status = discomgr.getDiSCOStatus(uri2OpenRdfIri(discoId), triplestore);
-		return status;
+		try {
+			RMapStatus status = discomgr.getDiSCOStatus(uri2OpenRdfIri(discoId), triplestore);
+			return status;
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -378,7 +422,9 @@ public class ORMapService implements RMapService {
 				throw new RMapException("Could not rollback changes after error. Please check your DiSCO record for errors.", ex);
 			}
 			throw ex;	
-		}	
+		}	finally {
+			closeConnection();
+		}
 		
 		return updateEvent;
 	}
@@ -407,7 +453,9 @@ public class ORMapService implements RMapService {
 				throw new RMapException("Could not rollback changes after error. Please check your DiSCO record for errors.", ex);
 			}
 			throw ex;	
-		}	
+		} finally {
+			closeConnection();
+		}
 		return inactivateEvent;
 	}
 
@@ -434,7 +482,9 @@ public class ORMapService implements RMapService {
 				throw new RMapException("Could not rollback changes after error. Please check your DiSCO record for errors.", ex);
 			}
 			throw ex;	
-		}	
+		} finally {
+			closeConnection();
+		}
 		return tombstoneEvent;
 	}
 
@@ -447,13 +497,17 @@ public class ORMapService implements RMapService {
 		if (discoID ==null){
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
 		}
-		Map<IRI,IRI>event2disco=
-				discomgr.getAllDiSCOVersions(uri2OpenRdfIri(discoID),
-						false,triplestore);
-		List<IRI> versions = new ArrayList<IRI>();
-		versions.addAll(event2disco.values());
-		List<URI> uris = ORAdapter.openRdfIriList2UriList(versions);
-		return uris;
+		try {
+			Map<IRI,IRI>event2disco=
+					discomgr.getAllDiSCOVersions(uri2OpenRdfIri(discoID),
+							false,triplestore);
+			List<IRI> versions = new ArrayList<IRI>();
+			versions.addAll(event2disco.values());
+			List<URI> uris = ORAdapter.openRdfIriList2UriList(versions);
+			return uris;
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -465,12 +519,16 @@ public class ORMapService implements RMapService {
 		if (discoID ==null){
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
 		}
-		Map<IRI,IRI>event2disco=
-				discomgr.getAllDiSCOVersions(uri2OpenRdfIri(discoID), true, triplestore);
-		List<IRI> versions = new ArrayList<IRI>();
-		versions.addAll(event2disco.values());		
-		List<URI> uris = ORAdapter.openRdfIriList2UriList(versions);
-		return uris;
+		try {
+			Map<IRI,IRI>event2disco=
+					discomgr.getAllDiSCOVersions(uri2OpenRdfIri(discoID), true, triplestore);
+			List<IRI> versions = new ArrayList<IRI>();
+			versions.addAll(event2disco.values());		
+			List<URI> uris = ORAdapter.openRdfIriList2UriList(versions);
+			return uris;
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -482,15 +540,18 @@ public class ORMapService implements RMapService {
 		if (discoID ==null){
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
 		}
-		Map<Date, IRI> date2disco = discomgr.getAllDiSCOVersionsWithDates(uri2OpenRdfIri(discoID), true, triplestore);
-		Map<Date, URI> versions = new TreeMap<Date, URI>();
-		for (Entry<Date,IRI> version:date2disco.entrySet()){			
-			versions.put(version.getKey(), ORAdapter.openRdfIri2URI(version.getValue()));
+		try {
+			Map<Date, IRI> date2disco = discomgr.getAllDiSCOVersionsWithDates(uri2OpenRdfIri(discoID), true, triplestore);
+			Map<Date, URI> versions = new TreeMap<Date, URI>();
+			for (Entry<Date,IRI> version:date2disco.entrySet()){			
+				versions.put(version.getKey(), ORAdapter.openRdfIri2URI(version.getValue()));
+			}
+			return versions;
+		} finally {
+			closeConnection();
 		}
-		return versions;
 	}
 	
-
 	/* (non-Javadoc)
 	 * @see info.rmapproject.core.rmapservice.RMapService#getDiSCOIdLatestVersion(java.net.URI)
 	 */
@@ -501,14 +562,18 @@ public class ORMapService implements RMapService {
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
 		}
 		IRI dUri  = uri2OpenRdfIri(discoID);
-		Map<IRI,IRI>event2disco=
-				discomgr.getAllDiSCOVersions(dUri, true, triplestore);
-		IRI latestDisco = discomgr.getLatestDiSCOIri(dUri, triplestore, event2disco);
-		URI discoURI = null;
-		if (latestDisco != null){
-			discoURI = ORAdapter.openRdfIri2URI(latestDisco);	
+		try {
+			Map<IRI,IRI>event2disco=
+					discomgr.getAllDiSCOVersions(dUri, true, triplestore);
+			IRI latestDisco = discomgr.getLatestDiSCOIri(dUri, triplestore, event2disco);
+			URI discoURI = null;
+			if (latestDisco != null){
+				discoURI = ORAdapter.openRdfIri2URI(latestDisco);	
+			}
+			return discoURI;
+		} finally {
+			closeConnection();
 		}
-		return discoURI;
 	}
 
 
@@ -523,14 +588,18 @@ public class ORMapService implements RMapService {
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
 		}
 		IRI thisUri = uri2OpenRdfIri(discoID);
-		URI nextDiscoUri = null;		
-		Map<IRI,IRI>event2disco= discomgr.getAllDiSCOVersions(thisUri, true, triplestore);
-		Map <Date, IRI> date2event =  eventmgr.getDate2EventMap(event2disco.keySet(),triplestore);	
-		IRI prevDisco = discomgr.getPreviousIRI(thisUri, event2disco, date2event, triplestore);
-		if (prevDisco != null){
-			nextDiscoUri = ORAdapter.openRdfIri2URI(prevDisco);
+		URI nextDiscoUri = null;	
+		try {
+			Map<IRI,IRI>event2disco= discomgr.getAllDiSCOVersions(thisUri, true, triplestore);
+			Map <Date, IRI> date2event =  eventmgr.getDate2EventMap(event2disco.keySet(),triplestore);	
+			IRI prevDisco = discomgr.getPreviousIRI(thisUri, event2disco, date2event, triplestore);
+			if (prevDisco != null){
+				nextDiscoUri = ORAdapter.openRdfIri2URI(prevDisco);
+			}
+			return nextDiscoUri;
+		} finally {
+			closeConnection();
 		}
-		return nextDiscoUri;
 	}
 
 
@@ -545,13 +614,17 @@ public class ORMapService implements RMapService {
 		}
 		IRI thisUri = uri2OpenRdfIri(discoID);
 		URI nextDiscoUri = null;
-		Map<IRI,IRI>event2disco=
-				discomgr.getAllDiSCOVersions(thisUri,true, triplestore);
-		IRI uri = discomgr.getNextIRI(thisUri, event2disco, null, triplestore);
-		if (uri != null){
-			nextDiscoUri = ORAdapter.openRdfIri2URI(uri);
+		try {
+			Map<IRI,IRI>event2disco=
+					discomgr.getAllDiSCOVersions(thisUri,true, triplestore);
+			IRI uri = discomgr.getNextIRI(thisUri, event2disco, null, triplestore);
+			if (uri != null){
+				nextDiscoUri = ORAdapter.openRdfIri2URI(uri);
+			}
+			return nextDiscoUri;
+		} finally {
+			closeConnection();
 		}
-		return nextDiscoUri;
 	}
 
 	/* (non-Javadoc)
@@ -562,9 +635,13 @@ public class ORMapService implements RMapService {
 		if (discoID ==null){
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
 		}
-		List<IRI> events = eventmgr.getDiscoRelatedEventIds(uri2OpenRdfIri(discoID), triplestore);
-		List<URI> uris = ORAdapter.openRdfIriList2UriList(events);
-		return uris;
+		try {
+			List<IRI> events = eventmgr.getDiscoRelatedEventIds(uri2OpenRdfIri(discoID), triplestore);
+			List<URI> uris = ORAdapter.openRdfIriList2UriList(events);
+			return uris;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -576,7 +653,11 @@ public class ORMapService implements RMapService {
 		if (eventId ==null){
 			throw new RMapDefectiveArgumentException ("Null event id");
 		}
-		return eventmgr.readEvent(uri2OpenRdfIri(eventId), triplestore);
+		try {
+			return eventmgr.readEvent(uri2OpenRdfIri(eventId), triplestore);
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -587,9 +668,13 @@ public class ORMapService implements RMapService {
 		if (eventID ==null){
 			throw new RMapDefectiveArgumentException ("Null event id");
 		}
-		List<IRI> resources = eventmgr.getAffectedResources(uri2OpenRdfIri(eventID), triplestore);
-		List<URI> resourceIds = ORAdapter.openRdfIriList2UriList(resources);
-		return resourceIds;
+		try {
+			List<IRI> resources = eventmgr.getAffectedResources(uri2OpenRdfIri(eventID), triplestore);
+			List<URI> resourceIds = ORAdapter.openRdfIriList2UriList(resources);
+			return resourceIds;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -600,9 +685,13 @@ public class ORMapService implements RMapService {
 		if (eventID ==null){
 			throw new RMapDefectiveArgumentException ("Null event id");
 		}
-		List<IRI> discos = eventmgr.getAffectedDiSCOs(uri2OpenRdfIri(eventID), triplestore);
-		List<URI> discoIds = ORAdapter.openRdfIriList2UriList(discos);
-		return discoIds;
+		try {
+			List<IRI> discos = eventmgr.getAffectedDiSCOs(uri2OpenRdfIri(eventID), triplestore);
+			List<URI> discoIds = ORAdapter.openRdfIriList2UriList(discos);
+			return discoIds;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -613,9 +702,13 @@ public class ORMapService implements RMapService {
 		if (eventID ==null){
 			throw new RMapDefectiveArgumentException ("Null event id");
 		}
-		List<IRI> agents = eventmgr.getAffectedAgents(uri2OpenRdfIri(eventID), triplestore);
-		List<URI> agentIds = ORAdapter.openRdfIriList2UriList(agents);
-		return agentIds;
+		try {
+			List<IRI> agents = eventmgr.getAffectedAgents(uri2OpenRdfIri(eventID), triplestore);
+			List<URI> agentIds = ORAdapter.openRdfIriList2UriList(agents);
+			return agentIds;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -627,8 +720,12 @@ public class ORMapService implements RMapService {
 		if (agentId==null){
 			throw new RMapDefectiveArgumentException("Null agentid");
 		}
-		ORMapAgent agent = agentmgr.readAgent(uri2OpenRdfIri(agentId), triplestore);
-		return agent;
+		try {
+			ORMapAgent agent = agentmgr.readAgent(uri2OpenRdfIri(agentId), triplestore);
+			return agent;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -658,7 +755,9 @@ public class ORMapService implements RMapService {
 				throw new RMapException("Could not rollback changes after error. Please check your Agent record for errors.", ex);
 			}
 			throw ex;	
-		}	
+		} finally {
+			closeConnection();
+		}
 		
 		return event;
 	}
@@ -756,7 +855,9 @@ public class ORMapService implements RMapService {
 				throw new RMapException("Could not rollback changes after error. Please check your Agent record for errors.", ex);
 			}
 			throw ex;	
-		}	
+		}	finally {
+			closeConnection();
+		}
 		return event;
 	}
 
@@ -797,8 +898,12 @@ public class ORMapService implements RMapService {
 	@Override
 	public ResultBatch<URI> getAgentDiSCOs(URI agentId, RMapSearchParams params) throws RMapException,
 			RMapDefectiveArgumentException {
-		UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> agentmgr.getAgentDiSCOs(iri, prms, triplestore);
-		return getUriBatch(agentId,params,uriBatchReq);
+		try {
+			UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> agentmgr.getAgentDiSCOs(iri, prms, triplestore);
+			return getUriBatch(agentId,params,uriBatchReq);
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -811,9 +916,13 @@ public class ORMapService implements RMapService {
 		if (agentId==null){
 			throw new RMapDefectiveArgumentException("Null agentId");
 		}
-		List<IRI> eventset = eventmgr.getAgentRelatedEventIds(uri, triplestore);		
-		List <URI> eventUris = ORAdapter.openRdfIriList2UriList(eventset);
-		return eventUris;
+		try {
+			List<IRI> eventset = eventmgr.getAgentRelatedEventIds(uri, triplestore);		
+			List <URI> eventUris = ORAdapter.openRdfIriList2UriList(eventset);
+			return eventUris;
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -822,8 +931,12 @@ public class ORMapService implements RMapService {
 	@Override
 	public ResultBatch<URI> getAgentEventsInitiated(URI agentId, RMapSearchParams params) throws RMapException,
 			RMapDefectiveArgumentException, RMapAgentNotFoundException {
-		UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> agentmgr.getAgentEventsInitiated(iri, prms, triplestore);
-		return getUriBatch(agentId, params, uriBatchReq);
+		try {
+			UriBatchRequest uriBatchReq = (iri, prms, triplestore) -> agentmgr.getAgentEventsInitiated(iri, prms, triplestore);
+			return getUriBatch(agentId, params, uriBatchReq);
+		} finally {
+			closeConnection();
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -835,8 +948,12 @@ public class ORMapService implements RMapService {
 			throw new RMapDefectiveArgumentException ("Null agentId");
 		}
 		IRI id = uri2OpenRdfIri(agentId);
-		RMapStatus status = agentmgr.getAgentStatus(id, triplestore);
-		return status;
+		try {
+			RMapStatus status = agentmgr.getAgentStatus(id, triplestore);
+			return status;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	
@@ -849,8 +966,12 @@ public class ORMapService implements RMapService {
 			throw new RMapDefectiveArgumentException ("Null Agent ID");
 		}
 		IRI id = uri2OpenRdfIri(agentId);
-		boolean isAgentId = agentmgr.isAgentId(id, triplestore);
-		return isAgentId;
+		try {
+			boolean isAgentId = agentmgr.isAgentId(id, triplestore);
+			return isAgentId;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -862,8 +983,12 @@ public class ORMapService implements RMapService {
 			throw new RMapDefectiveArgumentException ("Null Event ID");
 		}
 		IRI id = uri2OpenRdfIri(eventId);
-		boolean isEventId = eventmgr.isEventId(id, triplestore);
-		return isEventId;
+		try {
+			boolean isEventId = eventmgr.isEventId(id, triplestore);
+			return isEventId;
+		} finally {
+			closeConnection();
+		}
 	}
 
 	/* (non-Javadoc)
@@ -875,8 +1000,12 @@ public class ORMapService implements RMapService {
 			throw new RMapDefectiveArgumentException ("Null DiSCO ID");
 		}
 		IRI id = uri2OpenRdfIri(discoId);
-		boolean isDiSCOId = discomgr.isDiscoId(id, triplestore);
-		return isDiSCOId;
+		try {
+			boolean isDiSCOId = discomgr.isDiscoId(id, triplestore);
+			return isDiSCOId;
+		} finally {
+			closeConnection();
+		}
 	}
 
 
@@ -909,20 +1038,24 @@ public class ORMapService implements RMapService {
 		//set flag to check for next batch (this will get one extra record over requested amount)
 		params.setCheckNext(true);
 		
-		List<org.openrdf.model.IRI> iris = uriBatchRequest.retrieve(resource, params, triplestore);
-		
-		List<URI> uris = ORAdapter.openRdfIriList2UriList(iris);
-		
-		//if records go up to limit, there are more records to be retrieved
-		boolean hasNext = (uris.size()>params.getLimit());
-		//remove the extra record if there is one
-		if (hasNext){
-			uris.remove(uris.size()-1);					
+		try {
+			List<org.openrdf.model.IRI> iris = uriBatchRequest.retrieve(resource, params, triplestore);
+			
+			List<URI> uris = ORAdapter.openRdfIriList2UriList(iris);
+			
+			//if records go up to limit, there are more records to be retrieved
+			boolean hasNext = (uris.size()>params.getLimit());
+			//remove the extra record if there is one
+			if (hasNext){
+				uris.remove(uris.size()-1);					
+			}
+			
+			ResultBatch<URI> resultbatch = new ResultBatchImpl<URI>(uris, hasNext, params.getOffset()+1);		
+			
+			return resultbatch;		
+		} finally {
+			closeConnection();
 		}
-		
-		ResultBatch<URI> resultbatch = new ResultBatchImpl<URI>(uris, hasNext, params.getOffset()+1);		
-		
-		return resultbatch;				
 	}
 
 	/**
@@ -966,20 +1099,23 @@ public class ORMapService implements RMapService {
 		//set flag to check for next
 		params.setCheckNext(true);
 
-		List<org.openrdf.model.IRI> iris = uriBatchRequest.retrieve(orSubject, orPredicate, orObject, params, triplestore);
-		List<URI> uris = ORAdapter.openRdfIriList2UriList(iris);
-		
-		//if records are greater than limit, there are more records to be retrieved
-		boolean hasNext = (uris.size()>params.getLimit());
-		//remove the extra record if there is one
-		if (hasNext){
-			uris.remove(uris.size()-1);					
-		}
-		
-		ResultBatch<URI> resultbatch = new ResultBatchImpl<URI>(uris, hasNext, params.getOffset()+1);		
-		
-		return resultbatch;				
-		
+		try {
+			List<org.openrdf.model.IRI> iris = uriBatchRequest.retrieve(orSubject, orPredicate, orObject, params, triplestore);
+			List<URI> uris = ORAdapter.openRdfIriList2UriList(iris);
+			
+			//if records are greater than limit, there are more records to be retrieved
+			boolean hasNext = (uris.size()>params.getLimit());
+			//remove the extra record if there is one
+			if (hasNext){
+				uris.remove(uris.size()-1);					
+			}
+			
+			ResultBatch<URI> resultbatch = new ResultBatchImpl<URI>(uris, hasNext, params.getOffset()+1);		
+			
+			return resultbatch;			
+		} finally {
+			closeConnection();
+		}		
 	}
 	
 }

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapAgentMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapAgentMgrTest.java
@@ -72,9 +72,6 @@ public class ORMapAgentMgrTest extends ORMapMgrTest{
 		catch (RMapException e){
 			fail("exception" + e.getMessage());
 		}
-		finally {
-			rmapService.closeConnection();
-		}
 	}
 	
 	
@@ -134,9 +131,6 @@ public class ORMapAgentMgrTest extends ORMapMgrTest{
 		}
 		catch (URISyntaxException e){
 			fail("agent not found");
-		}
-		finally {
-			rmapService.closeConnection();
 		}
 		
 		

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapResourceMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapResourceMgrTest.java
@@ -132,9 +132,6 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 			e.printStackTrace();
 			fail();
 		}
-		finally {
-			rmapService.closeConnection();
-		}
 	}
 	
 	@SuppressWarnings("unused")
@@ -172,8 +169,6 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail();
-		} finally {
-			rmapService.closeConnection();
 		}
 		
 	}
@@ -221,9 +216,7 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail();
-		} finally {
-			rmapService.closeConnection();
-		}
+		} 
 	}
 	
 	@SuppressWarnings("unused")
@@ -271,9 +264,7 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail();
-		} finally {
-			rmapService.closeConnection();
-		}
+		} 
 		
 	}
 	

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/ResourceDisplayController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/ResourceDisplayController.java
@@ -94,8 +94,11 @@ public class ResourceDisplayController {
 		try {
 			if (resview==0) {
 				String rmapType = dataDisplayService.getRMapTypeDisplayName(new URI(sResourceUri));
+				log.debug("rmapType identified as " + rmapType);
 				if (rmapType.length()>0){
-					return "redirect:/" + rmapType.toLowerCase() + "s/" + URLEncoder.encode(sResourceUri, "UTF-8");
+					String redirectPath = "redirect:/" + rmapType.toLowerCase() + "s/" + URLEncoder.encode(sResourceUri, "UTF-8");
+					log.debug("Redirecting resource path to " + redirectPath);
+					return redirectPath;
 				}				
 			}
 			


### PR DESCRIPTION
- Connection was hanging due to apparent quirk with retrieving statements that contain a Resource that doesn't exist in the database.  This leaves the connection open and uses up the concurrent connections
allowed.  This was specifically a problem when checking for an RMap type using ORMapObjectMgr.isRMapType().  Now checks the context exists before checking the type statement.
- Some logging added to help resolve the issue
- Added code to webapp to ensure all connections close even when code errors
- Change ORMapService to use only Autowired constructor