### PR TITLE
Updated to point to new persistent ontology path

### DIFF
--- a/api/src/main/resources/create-rmap-agent.sql
+++ b/api/src/main/resources/create-rmap-agent.sql
@@ -1,4 +1,4 @@
-INSERT into Users(name, email, isActive, rmapAgentUri, authKeyUri, doRMapAgentSync, createdDate, lastAccessedDate) values ('RMap Test User', 'testuser@example.com', TRUE, 'rmap:testagenturi', 'http://rmap-project.org/authids/testauthid', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT into Users(name, email, isActive, rmapAgentUri, authKeyUri, doRMapAgentSync, createdDate, lastAccessedDate) values ('RMap Test User', 'testuser@example.com', TRUE, 'rmap:testagenturi', 'http://rmap-hub.org/authids/testauthid', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT into UserIdentityProviders(identityProvider, providerAccountId, providerAccountPublicId, providerAccountDisplayName, providerAccountProfileUrl, userId, createdDate, LASTAUTHENTICATEDDATE)
 values ('http://exampleidprovider.org', '1234567890', 'rmaptestuser', 'RMap Test User', 'https://exampleidprovider.org/rmaptestuser', (select userId from Users where name='RMap Test User'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/api/src/main/resources/rmapapi.properties
+++ b/api/src/main/resources/rmapapi.properties
@@ -1,6 +1,6 @@
 #rmapapi.path: path of api root.  In the code, this is primarily used 
 #to construct resource paths in the API response headers
-rmapapi.path=https\://fake.rmap-project.org/fake
+rmapapi.path=https\://fake.rmap-hub.org/fake
 #rmapapi.documentationPath: this is the path provided in response headers to indicate the location
 #of RMap API documentation
 rmapapi.documentationPath=https\://rmap-project.atlassian.net/wiki/display/RMAPPS/API+Documentation

--- a/api/src/test/java/info/rmapproject/api/responsemgr/DiscoResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/DiscoResponseManagerTest.java
@@ -182,7 +182,6 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 		assertEquals(200, response.getStatus());
 	}
 	
-
 	/**
 	 * Tests whether can retrieve response for updated DiSCO.
 	 *
@@ -231,7 +230,7 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 			assertTrue(links1.contains(encodedDiscoUri2 + successorAndLatestVersionLink));
 			assertTrue(!links1.contains(predecessorVersionLink));
 			assertTrue(links1.contains(">;rel=\"" + LinkRels.TIMEMAP + "\""));
-			assertTrue(links1.contains("/" + Terms.RMAP_INACTIVE));
+			assertTrue(links1.contains("#" + Terms.RMAP_INACTIVE));
 			assertTrue(links1.contains(">;rel=\"" + LinkRels.ORIGINAL + " " + LinkRels.TIMEGATE + "\""));
 			String location1 = response.getHeaderString("location");
 			assertTrue(location1.contains(encodedDiscoUri1));
@@ -250,7 +249,7 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 			assertTrue(links2.contains(encodedDiscoUri1 + predecessorVersionLink));
 			assertTrue(links2.contains(encodedDiscoUri2 + latestVersionLink));
 			assertTrue(!links2.contains(successorVersionLink));
-			assertTrue(links2.contains("/" + Terms.RMAP_ACTIVE));
+			assertTrue(links2.contains("#" + Terms.RMAP_ACTIVE));
 			assertTrue(links1.contains(">;rel=\"" + LinkRels.ORIGINAL + " " + LinkRels.TIMEGATE + "\""));
 			String location2 = response.getHeaderString(HttpHeaders.LOCATION);
 			assertTrue(location2.contains(encodedDiscoUri2));
@@ -404,7 +403,7 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 		Response response = discoResponseManager.getRMapDiSCO(strDiscoUri, RdfMediaType.APPLICATION_LDJSON);
 		assertTrue(response.getStatus()==410);//GONE
 		String links = response.getLinks().toString();
-		assertTrue(links.contains("/tombstoned"));
+		assertTrue(links.contains("#tombstoned"));
 		assertTrue(links.contains(encodedDiscoUri + "/latest>;rel=\"" + LinkRels.ORIGINAL + " " + LinkRels.TIMEGATE + "\""));
 	}
 	

--- a/api/src/test/java/info/rmapproject/api/responsemgr/EventResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/EventResponseManagerTest.java
@@ -136,7 +136,7 @@ public class EventResponseManagerTest extends ApiDataCreationTestAbstract {
 			String body = response.getEntity().toString();
 			//assertTrue(location.contains("event"));
 			
-			assertTrue(body.contains("<eventTargetType xmlns=\"http://rmap-project.org/rmap/terms/\" rdf:resource=\"http://rmap-project.org/rmap/terms/DiSCO\"/>"));
+			assertTrue(body.contains("<eventTargetType xmlns=\"http://purl.org/ontology/rmap#\" rdf:resource=\"http://purl.org/ontology/rmap#DiSCO\"/>"));
 			assertEquals(200, response.getStatus());
 			
 		} catch (Exception e) {

--- a/auth/src/main/resources/create-rmap-agent.sql
+++ b/auth/src/main/resources/create-rmap-agent.sql
@@ -1,4 +1,4 @@
-INSERT into Users(name, email, isActive, rmapAgentUri, authKeyUri, doRMapAgentSync, createdDate, lastAccessedDate) values ('RMap Test User', 'testuser@example.com', TRUE, 'rmap:testagenturi', 'http://rmap-project.org/authids/testauthid', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT into Users(name, email, isActive, rmapAgentUri, authKeyUri, doRMapAgentSync, createdDate, lastAccessedDate) values ('RMap Test User', 'testuser@example.com', TRUE, 'rmap:testagenturi', 'http://rmap-hub.org/authids/testauthid', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT into UserIdentityProviders(identityProvider, providerAccountId, providerAccountPublicId, providerAccountDisplayName, providerAccountProfileUrl, userId, createdDate, LASTAUTHENTICATEDDATE)
 values ('http://exampleidprovider.org', '1234567890', 'rmaptestuser', 'RMap Test User', 'https://exampleidprovider.org/rmaptestuser', (select userId from Users where name='RMap Test User'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/auth/src/test/java/info/rmapproject/auth/service/UserRMapAgentServiceImplTest.java
+++ b/auth/src/test/java/info/rmapproject/auth/service/UserRMapAgentServiceImplTest.java
@@ -44,7 +44,7 @@ public class UserRMapAgentServiceImplTest extends AuthDBTestAbstract {
 	String testUserName = "RMap Test User";
 	String testAgentUri = "rmap:testagenturi";
 	String testIdProvider = "http://exampleidprovider.org";
-	String testAuthKeyId = "http://rmap-project.org/authids/testauthid";
+	String testAuthKeyId = "http://rmap-hub.org/authids/testauthid";
 
 	String testUserName2 = "Different Name";
 	

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapAgentMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapAgentMgr.java
@@ -67,7 +67,7 @@ import static info.rmapproject.core.model.impl.openrdf.ORAdapter.uri2OpenRdfIri;
  * @author smorrissey, khanson
  */
 public class ORMapAgentMgr extends ORMapObjectMgr {
-
+	
 	/**
 	 * Get an Agent using Agent IRI and a specific triplestore instance
 	 *
@@ -371,17 +371,17 @@ public class ORMapAgentMgr extends ORMapObjectMgr {
 			WHERE { 
 			GRAPH ?rmapObjId  
 				{
-				?rmapObjId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/DiSCO> .	
+				?rmapObjId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#DiSCO> .	
 				} . 
 			 GRAPH ?eventId {
-				?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+				?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 				{?eventId <http://www.w3.org/ns/prov#generated> ?rmapObjId} UNION 
-				{?eventId <http://rmap-project.org/rmap/terms/derivedObject> ?rmapObjId} .
+				{?eventId <http://purl.org/ontology/rmap#derivedObject> ?rmapObjId} .
 				?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 				?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmaptestagent> .
 			} .
-			FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/tombstonedObject> ?rmapObjId} .
-			FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/inactivatedObject> ?rmapObjId}
+			FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#tombstonedObject> ?rmapObjId} .
+			FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#inactivatedObject> ?rmapObjId}
 			}
 		 */
 		
@@ -442,7 +442,7 @@ public class ORMapAgentMgr extends ORMapObjectMgr {
 		SELECT DISTINCT ?eventId 
 			WHERE {
 					GRAPH ?eventId {
-					 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+					 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 					 	?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 					 	?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/27927/rmp2543q5> .
 					 	}
@@ -500,6 +500,5 @@ public class ORMapAgentMgr extends ORMapObjectMgr {
 			throw new RMapAgentNotFoundException("The requesting agent is invalid. No Agent exists with IRI " + agentIri.stringValue());
 		}
 	}
-
-		
+	
 }

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapResourceMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapResourceMgr.java
@@ -73,12 +73,12 @@ public class ORMapResourceMgr extends ORMapObjectMgr {
 		  {
 		     {?s ?p <http://dx.doi.org/10.1109/InPar.2012.6339604>} UNION 
 		        {<http://dx.doi.org/10.1109/InPar.2012.6339604> ?p ?o} .
-		     ?discoId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/DiSCO> .
+		     ?discoId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#DiSCO> .
 		  } .
 		GRAPH ?eventId {
-		 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+		 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 			{?eventId <http://www.w3.org/ns/prov#generated> ?rmapObjId} UNION
-			{?eventId <http://rmap-project.org/rmap/terms/derivedObject> ?rmapObjId} .
+			{?eventId <http://purl.org/ontology/rmap#derivedObject> ?rmapObjId} .
 		 	?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 		 	{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd18nd2m3>} UNION
 		 	{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd18nd2p4>} .
@@ -240,7 +240,7 @@ public class ORMapResourceMgr extends ORMapObjectMgr {
 			        {<http://dx.doi.org/10.1109/InPar.2012.6339604> ?p ?o} .
 			  } .
 			GRAPH ?eventId {
-			 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+			 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 				?eventId ?eventtype ?rmapObjId .
 			 	?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 			 	{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd18nd2m3>} UNION
@@ -338,15 +338,15 @@ public class ORMapResourceMgr extends ORMapObjectMgr {
        			 }	
 			  } .
 			GRAPH ?eventId {
-			 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+			 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 				{?eventId <http://www.w3.org/ns/prov#generated> ?rmapObjId} UNION
-				{?eventId <http://rmap-project.org/rmap/terms/derivedObject> ?rmapObjId} .
+				{?eventId <http://purl.org/ontology/rmap#derivedObject> ?rmapObjId} .
 			 	?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 			 	{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd18nd2m3>} UNION
 			 	{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd18nd2p4>} .
 			 	} . 				
-				FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/tombstonedObject> ?rmapObjId} .
-				FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/inactivatedObject> ?rmapObjId} .
+				FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#tombstonedObject> ?rmapObjId} .
+				FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#inactivatedObject> ?rmapObjId} .
 				FILTER (?startDate >= "2016-03-22T10:20:13"^^xsd:dateTime) .        
                 FILTER (?startDate <= "2016-03-23T10:20:13"^^xsd:dateTime)
                                              }
@@ -485,15 +485,15 @@ public class ORMapResourceMgr extends ORMapObjectMgr {
 							 {<http://dx.doi.org/10.1109/ACSSC.1994.471497> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type} .	
 						  } .			    
 						GRAPH ?eventId {
-						 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+						 	?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 							{?eventId <http://www.w3.org/ns/prov#generated> ?rmapObjId} UNION
-							{?eventId <http://rmap-project.org/rmap/terms/derivedObject> ?rmapObjId} .
+							{?eventId <http://purl.org/ontology/rmap#derivedObject> ?rmapObjId} .
 							?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 						 	{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd18m7mj4>} . #UNION
 						 	{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd18nd2p4>} .
 						 	} . 				
-							FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/tombstonedObject> ?rmapObjId} .
-							FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/inactivatedObject> ?rmapObjId} .
+							FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#tombstonedObject> ?rmapObjId} .
+							FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#inactivatedObject> ?rmapObjId} .
 							FILTER (?startDate >= "2011-03-22T10:20:13"^^xsd:dateTime) .        
 			                FILTER (?startDate <= "2016-03-25T10:20:13"^^xsd:dateTime)    
 			}

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapStatementMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapStatementMgr.java
@@ -68,17 +68,17 @@ public class ORMapStatementMgr extends ORMapObjectMgr {
 		WHERE { 
 		 GRAPH ?rmapObjectId  {
 			 <http://dx.doi.org/10.1145/356502.356500> <http://purl.org/dc/terms/issued> "1978-12-01"^^<http://www.w3.org/2001/XMLSchema#date> . 
-			 ?discoId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/DiSCO> .
+			 ?discoId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#DiSCO> .
 		  } .
 		 GRAPH ?eventId {
-			?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+			?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 			{?eventId <http://www.w3.org/ns/prov#generated> ?rmapObjId} UNION
-			{?eventId <http://rmap-project.org/rmap/terms/derivedObject> ?rmapObjId} .
+			{?eventId <http://purl.org/ontology/rmap#derivedObject> ?rmapObjId} .
 			?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 			{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd18nd2m3>} .
 			} .
-			FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/tombstonedObject> ?rmapObjId} .
-			FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/inactivatedObject> ?rmapObjId} 
+			FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#tombstonedObject> ?rmapObjId} .
+			FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#inactivatedObject> ?rmapObjId} 
 		}
 		*/
 		List<IRI> discos = getRelatedObjects(subject, predicate, object, params,ts, RMAP.DISCO);
@@ -109,16 +109,16 @@ public class ORMapStatementMgr extends ORMapObjectMgr {
 		WHERE { 
 		  GRAPH ?rmapObjId {
 		    <http://isni.org/isni/000000010941358X> <http://xmlns.com/foaf/0.1/name> "IEEE" .
-		    ?rmapObjId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Agent> .
+		    ?rmapObjId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Agent> .
 		  } .
 		  GRAPH ?eventId {
-			?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+			?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 			{?eventId <http://www.w3.org/ns/prov#generated> ?rmapObjId} .
 			?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 			{?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> <ark:/22573/rmd3jq0>} .
 		  } .
-			FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/tombstonedObject> ?rmapObjId} .
-			FILTER NOT EXISTS {?statusChangeEventId <http://rmap-project.org/rmap/terms/inactivatedObject> ?rmapObjId} 
+			FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#tombstonedObject> ?rmapObjId} .
+			FILTER NOT EXISTS {?statusChangeEventId <http://purl.org/ontology/rmap#inactivatedObject> ?rmapObjId} 
 		}
 		*/
 		//note - active is the only status that is visible, so that is the filter.
@@ -251,9 +251,9 @@ public class ORMapStatementMgr extends ORMapObjectMgr {
 			  <http://dx.doi.org/10.1145/356502.356500> <http://purl.org/dc/terms/issued> "1978-12-01"^^<http://www.w3.org/2001/XMLSchema#date> .
 			  } .
 			  GRAPH ?eventId {
-				?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rmap-project.org/rmap/terms/Event> .
+				?eventId <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/rmap#Event> .
 				{?eventId <http://www.w3.org/ns/prov#generated> ?objectId} UNION
-				{?eventId <http://rmap-project.org/rmap/terms/derivedObject> ?objectId} .
+				{?eventId <http://purl.org/ontology/rmap#derivedObject> ?objectId} .
 				?eventId <http://www.w3.org/ns/prov#wasAssociatedWith> ?agentId .
 				?eventId <http://www.w3.org/ns/prov#startedAtTime> ?startDate .
 				} 

--- a/core/src/main/java/info/rmapproject/core/utils/Terms.java
+++ b/core/src/main/java/info/rmapproject/core/utils/Terms.java
@@ -27,7 +27,7 @@ public final class Terms  {
  	/*RMap vocabulary constants*/
 	
 	/** The RMap Namespace. */
-	public static final String RMAP_NAMESPACE = "http://rmap-project.org/rmap/terms/";
+	public static final String RMAP_NAMESPACE = "http://purl.org/ontology/rmap#";
 	 
  	/** The RMap prefix. */
  	public static final String RMAP_PREFIX = "rmap";

--- a/core/src/main/java/info/rmapproject/core/vocabulary/impl/openrdf/RMAP.java
+++ b/core/src/main/java/info/rmapproject/core/vocabulary/impl/openrdf/RMAP.java
@@ -31,13 +31,13 @@ import org.openrdf.model.impl.SimpleValueFactory;
  * Vocabulary constants for the RMapProject Metadata Element Set, version 1.0
  * The RMap ontology class implemented using openrdf model
  * 
- * @see http://rmap-project.org/rmap/terms
+ * @see http://purl.org/ontology/rmap
  * @author khanson
  */
 public class RMAP {
 
 	/**
-	 * RMapProject elements namespace: http://rmap-project.org/terms/
+	 * RMapProject elements namespace: http://purl.org/ontology/rmap#
 	 */
 	public static final String NAMESPACE = Terms.RMAP_NAMESPACE;
 	

--- a/testdata/src/main/java/info/rmapproject/testdata/service/TestConstants.java
+++ b/testdata/src/main/java/info/rmapproject/testdata/service/TestConstants.java
@@ -33,7 +33,7 @@ public class TestConstants {
 	public static final String SYSAGENT_ID_PROVIDER = "http://orcid.org/";
 
 	/** default system agent Auth ID to be used for most tests where Agent creation isn't being tested */
-	public static final String SYSAGENT_AUTH_ID = "http://rmap-project.org/identities/rmaptestauthid";
+	public static final String SYSAGENT_AUTH_ID = "http://rmap-hub.org/identities/rmaptestauthid";
 
 	/** default system agent name to be used for most tests where Agent creation isn't being tested */
 	public static final String SYSAGENT_NAME = "RMap test Agent";	
@@ -45,7 +45,7 @@ public class TestConstants {
 	public static final String SYSAGENT2_ID = "ark:/22573/rmaptestagent2";
 
 	/** second default system agent Auth ID to be used for tests where Agent creation isn't being tested but 2 agents needed*/
-	public static final String SYSAGENT2_AUTH_ID = "http://rmap-project.org/identities/rmaptestauthid2";
+	public static final String SYSAGENT2_AUTH_ID = "http://rmap-hub.org/identities/rmaptestauthid2";
 
 	/** second default system agent name to be used for tests where Agent creation isn't being tested but 2 agents needed*/
 	public static final String SYSAGENT2_NAME = "RMap test Agent 2";	

--- a/testdata/src/main/resources/agents/agentA.jsonld
+++ b/testdata/src/main/resources/agents/agentA.jsonld
@@ -3,7 +3,7 @@
     "foaf": "http://xmlns.com/foaf/0.1/",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "rmap": "http://rmap-project.org/rmap/terms/",
+    "rmap": "http://purl.org/ontology/rmap#",
     "xsd": "http://www.w3.org/2001/XMLSchema#"
   },
   "@id": "ark:/22573/rmaptestagent",
@@ -13,6 +13,6 @@
     "@id": "http://orcid.org/"
   },
   "rmap:userAuthId": {
-    "@id": "http://rmap-project.org/identities/rmaptestauthid"
+    "@id": "http://rmap-hub.org/identities/rmaptestauthid"
   }
 }

--- a/testdata/src/main/resources/agents/agentA.rdf
+++ b/testdata/src/main/resources/agents/agentA.rdf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:about="ark:/22573/rmaptestagent">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/Agent"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#Agent"/>
         <foaf:name>RMap test Agent</foaf:name>
         <rmap:identityProvider rdf:resource="http://orcid.org/"/>
-        <rmap:userAuthId rdf:resource="http://rmap-project.org/identities/rmaptestauthid"/>
+        <rmap:userAuthId rdf:resource="http://rmap-hub.org/identities/rmaptestauthid"/>
     </rdf:Description>
 </rdf:RDF>

--- a/testdata/src/main/resources/agents/agentA.ttl
+++ b/testdata/src/main/resources/agents/agentA.ttl
@@ -1,8 +1,8 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix rmap: <http://rmap-project.org/rmap/terms/> .
+@prefix rmap: <http://purl.org/ontology/rmap#> .
 
 <ark:/22573/rmaptestagent>
-  a <http://rmap-project.org/rmap/terms/Agent> ;
+  a <http://purl.org/ontology/rmap#Agent> ;
   foaf:name "RMap test Agent" ;
   rmap:identityProvider <http://orcid.org/> ;
-  rmap:userAuthId <http://rmap-project.org/identities/rmaptestauthid> .
+  rmap:userAuthId <http://rmap-hub.org/identities/rmaptestauthid> .

--- a/testdata/src/main/resources/agents/agentA_noauthid.rdf
+++ b/testdata/src/main/resources/agents/agentA_noauthid.rdf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:about="ark:/22573/rmaptestagent">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/Agent"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#Agent"/>
         <foaf:name>RMap test Agent</foaf:name>
         <rmap:identityProvider rdf:resource="http://orcid.org/"/>
     </rdf:Description>

--- a/testdata/src/main/resources/agents/agentA_noid.rdf
+++ b/testdata/src/main/resources/agents/agentA_noid.rdf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/Agent"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#Agent"/>
         <foaf:name>RMap test Agent</foaf:name>
         <rmap:identityProvider rdf:resource="http://orcid.org/"/>
-        <rmap:userAuthId rdf:resource="http://rmap-project.org/identities/rmaptestauthid"/>
+        <rmap:userAuthId rdf:resource="http://rmap-hub.org/identities/rmaptestauthid"/>
     </rdf:Description>
 </rdf:RDF>

--- a/testdata/src/main/resources/agents/agentA_noidprovider.rdf
+++ b/testdata/src/main/resources/agents/agentA_noidprovider.rdf
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:about="ark:/22573/rmaptestagent">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/Agent"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#Agent"/>
         <foaf:name>RMap test Agent</foaf:name>
-        <rmap:userAuthId rdf:resource="http://rmap-project.org/identities/rmaptestauthid"/>
+        <rmap:userAuthId rdf:resource="http://rmap-hub.org/identities/rmaptestauthid"/>
     </rdf:Description>
 </rdf:RDF>

--- a/testdata/src/main/resources/agents/agentA_noname.rdf
+++ b/testdata/src/main/resources/agents/agentA_noname.rdf
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:about="ark:/22573/rmaptestagent">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/Agent"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#Agent"/>
         <rmap:identityProvider rdf:resource="http://orcid.org/"/>
-        <rmap:userAuthId rdf:resource="http://rmap-project.org/identities/rmaptestauthid"/>
+        <rmap:userAuthId rdf:resource="http://rmap-hub.org/identities/rmaptestauthid"/>
     </rdf:Description>
 </rdf:RDF>

--- a/testdata/src/main/resources/agents/agentA_notype.rdf
+++ b/testdata/src/main/resources/agents/agentA_notype.rdf
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:about="ark:/22573/rmaptestagent">
         <foaf:name>RMap test Agent</foaf:name>
         <rmap:identityProvider rdf:resource="http://orcid.org/"/>
-        <rmap:userAuthId rdf:resource="http://rmap-project.org/identities/rmaptestauthid"/>
+        <rmap:userAuthId rdf:resource="http://rmap-hub.org/identities/rmaptestauthid"/>
     </rdf:Description>
 </rdf:RDF>

--- a/testdata/src/main/resources/agents/agentB_v1.rdf
+++ b/testdata/src/main/resources/agents/agentB_v1.rdf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:about="ark:/22573/rmaptestagent2">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/Agent"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#Agent"/>
         <foaf:name>RMap test Agent 2</foaf:name>
         <rmap:identityProvider rdf:resource="http://orcid.org/"/>
-        <rmap:userAuthId rdf:resource="http://rmap-project.org/identities/rmaptestauthid2"/>
+        <rmap:userAuthId rdf:resource="http://rmap-hub.org/identities/rmaptestauthid2"/>
     </rdf:Description>
 </rdf:RDF>

--- a/testdata/src/main/resources/agents/agentB_v2.rdf
+++ b/testdata/src/main/resources/agents/agentB_v2.rdf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:about="ark:/22573/rmaptestagent2">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/Agent"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#Agent"/>
         <foaf:name>Test agent with another name</foaf:name>
         <rmap:identityProvider rdf:resource="http://orcid.org/"/>
-        <rmap:userAuthId rdf:resource="http://rmap-project.org/identities/rmaptestauthid2"/>
+        <rmap:userAuthId rdf:resource="http://rmap-hub.org/identities/rmaptestauthid2"/>
     </rdf:Description>
 </rdf:RDF>

--- a/testdata/src/main/resources/agents/agentB_v3.rdf
+++ b/testdata/src/main/resources/agents/agentB_v3.rdf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rmap="http://rmap-project.org/rmap/terms/"
+	xmlns:rmap="http://purl.org/ontology/rmap#"
 	xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <rdf:Description rdf:about="ark:/22573/rmaptestagent2">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/Agent"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#Agent"/>
         <foaf:name>Test agent with another name</foaf:name>
         <rmap:identityProvider rdf:resource="http://google.com/"/>
-        <rmap:userAuthId rdf:resource="http://rmap-project.org/identities/abcdef"/>
+        <rmap:userAuthId rdf:resource="http://rmap-hub.org/identities/abcdef"/>
     </rdf:Description>
 </rdf:RDF>

--- a/testdata/src/main/resources/discos/discoA.jsonld
+++ b/testdata/src/main/resources/discos/discoA.jsonld
@@ -14,7 +14,7 @@
   "@graph": [
     {
       "@id": "_:N941f160863534fc5ad60b8755f77bd37",
-      "@type": "http://rmap-project.org/rmap/terms/DiSCO",
+      "@type": "http://purl.org/ontology/rmap#DiSCO",
       "dc:description": "This is a made up example of an IEEE DiSCO.",
       "dcterms:creator": {
         "@id": "http://isni.org/isni/0000000122976723"

--- a/testdata/src/main/resources/discos/discoA.rdf
+++ b/testdata/src/main/resources/discos/discoA.rdf
@@ -9,7 +9,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/disco.test"/>

--- a/testdata/src/main/resources/discos/discoA.ttl
+++ b/testdata/src/main/resources/discos/discoA.ttl
@@ -5,9 +5,9 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ieee: <http://data.ieee.org/ieee/terms/> .
 @prefix ore: <http://www.openarchives.org/ore/terms/> .
-@prefix rmap: <http://rmap-project.org/rmap/terms/> .
+@prefix rmap: <http://purl.org/ontology/rmap#> .
 
-[] a <http://rmap-project.org/rmap/terms/DiSCO> ;
+[] a <http://purl.org/ontology/rmap#DiSCO> ;
 	dcterms:creator <http://isni.org/isni/0000000122976723> ;
 	dc:description "This is a made up example of an IEEE DiSCO." ;
 	ore:aggregates <http://doi.org/10.1109/disco.test> ;

--- a/testdata/src/main/resources/discos/discoA_aggregatesonly.rdf
+++ b/testdata/src/main/resources/discos/discoA_aggregatesonly.rdf
@@ -3,7 +3,7 @@
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:ore="http://www.openarchives.org/ore/terms/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/discoa.test"/>
         <ore:aggregates rdf:resource="http://ieeexplore.ieee.org/example/000000-mm.zip"/>
     </rdf:Description>

--- a/testdata/src/main/resources/discos/discoA_badsyntax.rdf
+++ b/testdata/src/main/resources/discos/discoA_badsyntax.rdf
@@ -9,7 +9,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/discoa.test"/>

--- a/testdata/src/main/resources/discos/discoA_encodedspaceinurl.rdf
+++ b/testdata/src/main/resources/discos/discoA_encodedspaceinurl.rdf
@@ -9,7 +9,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/discoa.test"/>

--- a/testdata/src/main/resources/discos/discoA_noaggregates.rdf
+++ b/testdata/src/main/resources/discos/discoA_noaggregates.rdf
@@ -9,7 +9,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
     </rdf:Description>

--- a/testdata/src/main/resources/discos/discoA_nobody.rdf
+++ b/testdata/src/main/resources/discos/discoA_nobody.rdf
@@ -5,7 +5,7 @@
 	xmlns:ore="http://www.openarchives.org/ore/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/disco.test"/>

--- a/testdata/src/main/resources/discos/discoA_nobody_noaggregates.rdf
+++ b/testdata/src/main/resources/discos/discoA_nobody_noaggregates.rdf
@@ -6,7 +6,7 @@
 	xmlns:ore="http://www.openarchives.org/ore/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
     </rdf:Description>

--- a/testdata/src/main/resources/discos/discoA_notconnected.rdf
+++ b/testdata/src/main/resources/discos/discoA_notconnected.rdf
@@ -9,7 +9,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/disco.test"/>

--- a/testdata/src/main/resources/discos/discoA_withbnodes.jsonld
+++ b/testdata/src/main/resources/discos/discoA_withbnodes.jsonld
@@ -14,7 +14,7 @@
   "@graph": [
     {
       "@id": "_:N53ab4e2e5a454b8bbc25e35776614897",
-      "@type": "http://rmap-project.org/rmap/terms/DiSCO",
+      "@type": "http://purl.org/ontology/rmap#DiSCO",
       "dc:description": "This is a made up example of an IEEE DiSCO.",
       "dcterms:creator": {
         "@id": "http://isni.org/isni/0000000122976723"

--- a/testdata/src/main/resources/discos/discoA_withbnodes.rdf
+++ b/testdata/src/main/resources/discos/discoA_withbnodes.rdf
@@ -10,7 +10,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/">
 	
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/disco.test"/>

--- a/testdata/src/main/resources/discos/discoA_withbnodes.ttl
+++ b/testdata/src/main/resources/discos/discoA_withbnodes.ttl
@@ -5,9 +5,9 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ieee: <http://data.ieee.org/ieee/terms/> .
 @prefix ore: <http://www.openarchives.org/ore/terms/> .
-@prefix rmap: <http://rmap-project.org/rmap/terms/> .
+@prefix rmap: <http://purl.org/ontology/rmap#> .
 
-[] a <http://rmap-project.org/rmap/terms/DiSCO> ;
+[] a <http://purl.org/ontology/rmap#DiSCO> ;
 	dcterms:creator <http://isni.org/isni/0000000122976723> ;
 	dc:description "This is a made up example of an IEEE DiSCO." ;
 	ore:aggregates <http://doi.org/10.1109/disco.test> ;

--- a/testdata/src/main/resources/discos/discoA_withproviderid.rdf
+++ b/testdata/src/main/resources/discos/discoA_withproviderid.rdf
@@ -9,7 +9,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:about="ark:/00000/providerid">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/disco.test"/>

--- a/testdata/src/main/resources/discos/discoA_x2.rdf
+++ b/testdata/src/main/resources/discos/discoA_x2.rdf
@@ -9,7 +9,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65570">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/disco.test"/>
@@ -67,7 +67,7 @@
 	xmlns:ieee="http://data.ieee.org/ieee/terms/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/">
     <rdf:Description rdf:nodeID="N65571">
-        <rdf:type rdf:resource="http://rmap-project.org/rmap/terms/DiSCO"/>
+        <rdf:type rdf:resource="http://purl.org/ontology/rmap#DiSCO"/>
         <dcterms:creator rdf:resource="http://isni.org/isni/0000000122976723"/>
         <dc:description>This is a made up example of an IEEE DiSCO.</dc:description>
         <ore:aggregates rdf:resource="http://doi.org/10.1109/disco.test"/>

--- a/testdata/src/main/resources/discos/discoB_v1.rdf
+++ b/testdata/src/main/resources/discos/discoB_v1.rdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
-    xmlns:rmap="http://rmap-project.org/rmap/terms/" 
+    xmlns:rmap="http://purl.org/ontology/rmap#" 
     xmlns:ore="http://www.openarchives.org/ore/terms/"
     xmlns:dc="http://purl.org/dc/elements/1.1/" 
     xmlns:dcterms="http://purl.org/dc/terms/" 

--- a/testdata/src/main/resources/discos/discoB_v2.rdf
+++ b/testdata/src/main/resources/discos/discoB_v2.rdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
-    xmlns:rmap="http://rmap-project.org/rmap/terms/" 
+    xmlns:rmap="http://purl.org/ontology/rmap#" 
     xmlns:ore="http://www.openarchives.org/ore/terms/"
     xmlns:dc="http://purl.org/dc/elements/1.1/" 
     xmlns:dcterms="http://purl.org/dc/terms/" 

--- a/testdata/src/main/resources/discos/discoB_v3.rdf
+++ b/testdata/src/main/resources/discos/discoB_v3.rdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
-    xmlns:rmap="http://rmap-project.org/rmap/terms/" 
+    xmlns:rmap="http://purl.org/ontology/rmap#" 
     xmlns:ore="http://www.openarchives.org/ore/terms/"
     xmlns:dc="http://purl.org/dc/elements/1.1/" 
     xmlns:dcterms="http://purl.org/dc/terms/" 

--- a/testdata/src/main/resources/discos/discoB_v4.rdf
+++ b/testdata/src/main/resources/discos/discoB_v4.rdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
-    xmlns:rmap="http://rmap-project.org/rmap/terms/" 
+    xmlns:rmap="http://purl.org/ontology/rmap#" 
     xmlns:ore="http://www.openarchives.org/ore/terms/"
     xmlns:dc="http://purl.org/dc/elements/1.1/" 
     xmlns:dcterms="http://purl.org/dc/terms/" 

--- a/webapp/src/main/resources/create-rmap-agent.sql
+++ b/webapp/src/main/resources/create-rmap-agent.sql
@@ -1,4 +1,4 @@
-INSERT into Users(name, email, isActive, rmapAgentUri, authKeyUri, doRMapAgentSync, createdDate, lastAccessedDate) values ('RMap Test User', 'testuser@example.com', TRUE, 'rmap:testagenturi', 'http://rmap-project.org/authids/testauthid', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT into Users(name, email, isActive, rmapAgentUri, authKeyUri, doRMapAgentSync, createdDate, lastAccessedDate) values ('RMap Test User', 'testuser@example.com', TRUE, 'rmap:testagenturi', 'http://rmap-hub.org/authids/testauthid', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT into UserIdentityProviders(identityProvider, providerAccountId, providerAccountPublicId, providerAccountDisplayName, providerAccountProfileUrl, userId, createdDate, LASTAUTHENTICATEDDATE)
 values ('http://exampleidprovider.org', '1234567890', 'rmaptestuser', 'RMap Test User', 'https://exampleidprovider.org/rmaptestuser', (select userId from Users where name='RMap Test User'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/webapp/src/main/resources/ontologyprefixes.properties
+++ b/webapp/src/main/resources/ontologyprefixes.properties
@@ -3,7 +3,7 @@
 http\://www.w3.org/1999/02/22-rdf-syntax-ns\#=rdf
 http\://purl.org/spar/datacite/=datacite
 http\://www.w3.org/2000/01/rdf-schema\#=rdfs
-http\://rmap-project.org/rmap/terms/=rmap
+http\://purl.org/ontology/rmap\#=rmap
 http\://www.w3.org/ns/prov\#=prov
 http\://www.w3.org/2002/07/owl\#=owl
 http\://www.openarchives.org/ore/terms/=ore

--- a/webapp/src/main/resources/typemappings.properties
+++ b/webapp/src/main/resources/typemappings.properties
@@ -2,9 +2,9 @@
 #Note the types must match a property in the nodetypes.properties file
 #[rdfType]=[groupName]
 #DiSCOs 
-http\://rmap-project.org/rmap/terms/DiSCO=DiSCO
+http\://purl.org/ontology/rmap#DiSCO=DiSCO
 #Agents
-http\://rmap-project.org/rmap/terms/Agent=Agent
+http\://purl.org/ontology/rmap#Agent=Agent
 http\://xmlns.com/foaf/0.1/Agent=Agent
 http\://xmlns.com/foaf/0.1/Person=Agent
 http\://xmlns.com/foaf/0.1/Organization=Agent

--- a/webapp/src/main/webapp/WEB-INF/views/search.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/search.jsp
@@ -21,7 +21,7 @@
 		<input type="submit" value="GO" style="margin-top:3px;">
 		<p style="font-size: 85%;">Examples: 
 		<a href="<c:url value='/resources/rmap%3Armd18n8xfs'/>">rmap:rmd18n8xfs</a>, 
-		<a href="<c:url value='/resources/http%3A%2F%2Fdx.doi.org%2F10.1109%2FInPar.2012.6339604'/>">http://dx.doi.org/10.1109/InPar.2012.6339604</a>, 
+		<a href="<c:url value='/resources/https%3A%2F%2Fdoi.org%2F10.1109%2FInPar.2012.6339604'/>">https://doi.org/10.1109/InPar.2012.6339604</a>, 
 		<a href="<c:url value='/resources/https%3A%2F%2Fosf.io%2Frxgmb%2F'/>">https://osf.io/rxgmb/</a></p><br/>
 	</form:form>
 	<br/>

--- a/webapp/src/test/java/info/rmapproject/webapp/utils/WebappUtilsTest.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/utils/WebappUtilsTest.java
@@ -39,7 +39,7 @@ public class WebappUtilsTest extends WebTestAbstract {
 	 */
 	@Test
 	public void testOntologyPrefixes() {
-		String url = "http://rmap-project.org/rmap/terms/DiSCO";
+		String url = "http://purl.org/ontology/rmap#DiSCO";
 
 		String newUrl = WebappUtils.replaceNamespace(url);
 		
@@ -58,12 +58,12 @@ public class WebappUtilsTest extends WebTestAbstract {
 	 */
 	@Test
 	public void testNodeTypeRetrieval() throws Exception {
-		String url = "http://rmap-project.org/rmap/terms/DiSCO";
+		String url = "http://purl.org/ontology/rmap#DiSCO";
 		String nodeType = WebappUtils.getNodeType(new URI(url));
 		assertTrue(nodeType.equals("DiSCO"));
 
 		List<URI> uris = new ArrayList<URI>();
-		uris.add(new URI("http://rmap-project.org/rmap/terms/DiSCO"));
+		uris.add(new URI("http://purl.org/ontology/rmap#DiSCO"));
 		uris.add(new URI("http://purl.org/dc/terms/Agent"));
 		uris.add(new URI("http://purl.org/dc/dcmitype/Text"));
 		uris.add(new URI("http://purl.org/spar/fabio/JournalArticle"));

--- a/webapp/src/test/resources/typemappings.properties
+++ b/webapp/src/test/resources/typemappings.properties
@@ -1,9 +1,9 @@
 #map group to rdf:type. This will indicate which RDF:TYPEs will have a distinct color/shape in the visualization
 #Note the types must match a property in the nodetypes.properties file
 #DiSCOs
-http\://rmap-project.org/rmap/terms/DiSCO=DiSCO
+http\://purl.org/ontology/rmap\#DiSCO=DiSCO
 #Agents
-http\://rmap-project.org/rmap/terms/Agent=Agent
+http\://purl.org/ontology/rmap\#Agent=Agent
 http\://xmlns.com/foaf/0.1/Agent=Agent
 http\://xmlns.com/foaf/0.1/Person=Agent
 http\://xmlns.com/foaf/0.1/Organization=Agent


### PR DESCRIPTION
A find and replace to change all rmap-project.org paths to rmap-hub.org and all http://rmap-project.org/rmap/terms/ paths to new persistent path at http://purl.org/ontology/rmap# namespace.

This is for issue #26