### PR TITLE
Rename RMapRequestAgent to RequestEventDetails, expand to include description

### DIFF
--- a/api/src/main/java/info/rmapproject/api/auth/ApiUserService.java
+++ b/api/src/main/java/info/rmapproject/api/auth/ApiUserService.java
@@ -20,7 +20,7 @@
 package info.rmapproject.api.auth;
 
 import info.rmapproject.api.exception.RMapApiException;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 
 import java.net.URI;
 
@@ -139,11 +139,12 @@ public interface ApiUserService {
 	
 
 	/**
-	 * Constructs current Request Agent object based on authenticated user. Throws exception if there is no Agent
+	 * Constructs current Request Event Details object based on authenticated user. This will be used to pass information
+	 * to RMap for updates. Throws exception if there is no Agent
 	 *
 	 * @return the current request agent
 	 * @throws RMapApiException the RMap API Exception
 	 */
-	public RMapRequestAgent getCurrentRequestAgent() throws RMapApiException;
+	public RequestEventDetails getCurrentRequestEventDetails() throws RMapApiException;
 
 }

--- a/api/src/main/java/info/rmapproject/api/auth/ApiUserServiceImpl.java
+++ b/api/src/main/java/info/rmapproject/api/auth/ApiUserServiceImpl.java
@@ -35,7 +35,7 @@ import info.rmapproject.auth.exception.RMapAuthException;
 import info.rmapproject.auth.model.ApiKey;
 import info.rmapproject.auth.model.User;
 import info.rmapproject.auth.service.RMapAuthService;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 
 /**
  * Implementation of the API User Service, which manages interaction between rmap-auth and the API. 
@@ -222,16 +222,16 @@ public class ApiUserServiceImpl implements ApiUserService {
 	}
 
     /* (non-Javadoc)
-	 * @see info.rmapproject.api.auth.ApiUserServiceInt#getCurrentRequestAgent()
+	 * @see info.rmapproject.api.auth.ApiUserServiceInt#getCurrentRequestEventDetails()
 	 */
 	@Override
-	public RMapRequestAgent getCurrentRequestAgent() throws RMapApiException {
+	public RequestEventDetails getCurrentRequestEventDetails() throws RMapApiException {
 		URI currSystemAgent = getCurrentSystemAgentUri();
 		if (currSystemAgent ==  null){
 			throw new RMapApiException(ErrorCode.ER_USER_HAS_NO_AGENT);
 		}
-		RMapRequestAgent requestAgent = new RMapRequestAgent(getCurrentSystemAgentUri(), getApiKeyForEvent());
-		return requestAgent;
+		RequestEventDetails reqEventDetails = new RequestEventDetails(getCurrentSystemAgentUri(), getApiKeyForEvent());
+		return reqEventDetails;
 	}
 
 }

--- a/api/src/main/java/info/rmapproject/api/responsemgr/DiscoResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/DiscoResponseManager.java
@@ -65,7 +65,7 @@ import info.rmapproject.core.model.RMapStatus;
 import info.rmapproject.core.model.disco.RMapDiSCO;
 import info.rmapproject.core.model.event.RMapEvent;
 import info.rmapproject.core.model.event.RMapEventCreation;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rdfhandler.RDFHandler;
 import info.rmapproject.core.rdfhandler.RDFType;
 import info.rmapproject.core.rmapservice.RMapService;
@@ -438,9 +438,9 @@ public class DiscoResponseManager extends ResponseManager {
 			//Ensure user has been converted to an RMapAgent
 			apiUserService.prepareCurrentUserForWriteAccess();
 			//Retrieve agent to associate with Event
-			RMapRequestAgent reqAgent = apiUserService.getCurrentRequestAgent();
+			RequestEventDetails reqEventDetails = apiUserService.getCurrentRequestEventDetails();
 			
-			RMapEventCreation discoEvent = (RMapEventCreation)rmapService.createDiSCO(rmapDisco, reqAgent);
+			RMapEventCreation discoEvent = (RMapEventCreation)rmapService.createDiSCO(rmapDisco, reqEventDetails);
 			if (discoEvent == null) {
 				throw new RMapApiException(ErrorCode.ER_CORE_CREATEDISCO_NOT_COMPLETED);
 			} 
@@ -532,9 +532,9 @@ public class DiscoResponseManager extends ResponseManager {
 			//Ensure user has been converted to an RMapAgent
 			apiUserService.prepareCurrentUserForWriteAccess();
 			//Retrieve agent to associate with Event
-			RMapRequestAgent reqAgent = apiUserService.getCurrentRequestAgent();
+			RequestEventDetails reqEventDetails = apiUserService.getCurrentRequestEventDetails();
 			
-			RMapEvent discoEvent = rmapService.updateDiSCO(uriOrigDiscoUri, newRmapDisco, reqAgent);
+			RMapEvent discoEvent = rmapService.updateDiSCO(uriOrigDiscoUri, newRmapDisco, reqEventDetails);
 			
 			if (discoEvent == null) {
 				throw new RMapApiException(ErrorCode.ER_CORE_UPDATEDISCO_NOT_COMPLETED);
@@ -662,14 +662,14 @@ public class DiscoResponseManager extends ResponseManager {
 			//Ensure user has been converted to an RMapAgent
 			apiUserService.prepareCurrentUserForWriteAccess();
 			//Retrieve agent to associate with Event
-			RMapRequestAgent reqAgent = apiUserService.getCurrentRequestAgent();
+			RequestEventDetails reqEventDets = apiUserService.getCurrentRequestEventDetails();
 			
 			RMapEvent discoEvent = null;
 			if (newStatus.equals("TOMBSTONED"))	{
-				discoEvent = rmapService.deleteDiSCO(uriDiscoUri, reqAgent);
+				discoEvent = rmapService.deleteDiSCO(uriDiscoUri, reqEventDets);
 			}
 			else if (newStatus.equals("INACTIVE"))	{
-				discoEvent = rmapService.inactivateDiSCO(uriDiscoUri, reqAgent);
+				discoEvent = rmapService.inactivateDiSCO(uriDiscoUri, reqEventDets);
 			}
 				
 			if (discoEvent == null) {

--- a/api/src/test/java/info/rmapproject/api/ApiDataCreationTestAbstract.java
+++ b/api/src/test/java/info/rmapproject/api/ApiDataCreationTestAbstract.java
@@ -35,7 +35,7 @@ import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.model.impl.openrdf.ORAdapter;
 import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rdfhandler.RDFHandler;
 import info.rmapproject.core.rmapservice.RMapService;
 import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameSailMemoryTriplestore;
@@ -73,8 +73,8 @@ public abstract class ApiDataCreationTestAbstract extends ApiTestAbstract {
 	/** General use sysagent for testing **/
 	protected ORMapAgent sysagent = null;
 	
-	/** Request agent based on sysagent. Include key */
-	protected RMapRequestAgent requestAgent = null;
+	/** Request event details includes sysagent and optional key URI and event description */
+	protected RequestEventDetails requestEventDetails = null;
 		
 	@Before
 	public void setUp() throws Exception {
@@ -110,14 +110,14 @@ public abstract class ApiDataCreationTestAbstract extends ApiTestAbstract {
 			Literal NAME = ORAdapter.getValueFactory().createLiteral(TestConstants.SYSAGENT_NAME);	
 			sysagent = new ORMapAgent(AGENT_IRI, ID_PROVIDER_IRI, AUTH_ID_IRI, NAME);
 			
-			if (requestAgent==null){
-				requestAgent = new RMapRequestAgent(new URI(TestConstants.SYSAGENT_ID),new URI(TestConstants.SYSAGENT_KEY));
+			if (requestEventDetails==null){
+				requestEventDetails = new RequestEventDetails(new URI(TestConstants.SYSAGENT_ID),new URI(TestConstants.SYSAGENT_KEY));
 			}
 			
 			//create new test agent
 			URI agentId=sysagent.getId().getIri();
 			if (!rmapService.isAgentId(agentId)) {
-				rmapService.createAgent(sysagent,requestAgent);
+				rmapService.createAgent(sysagent,requestEventDetails);
 			}
 
 			// Check the agent was created

--- a/api/src/test/java/info/rmapproject/api/responsemgr/AgentResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/AgentResponseManagerTest.java
@@ -139,13 +139,13 @@ public class AgentResponseManagerTest extends ApiDataCreationTestAbstract {
 		RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 		String discoURI = rmapDisco.getId().toString();
         assertNotNull(discoURI);
-		rmapService.createDiSCO(rmapDisco, requestAgent);
+		rmapService.createDiSCO(rmapDisco, requestEventDetails);
 
 		//createDisco
 		RMapDiSCO rmapDisco2 = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 		String discoURI2 = rmapDisco2.getId().toString();
         assertNotNull(discoURI2);
-		rmapService.createDiSCO(rmapDisco2, requestAgent);
+		rmapService.createDiSCO(rmapDisco2, requestEventDetails);
 	
 		try {
 			MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
@@ -202,13 +202,13 @@ public class AgentResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco, requestAgent);
+			rmapService.createDiSCO(rmapDisco, requestEventDetails);
 	
 			//createDisco
 			RMapDiSCO rmapDisco2 = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI2 = rmapDisco2.getId().toString();
 	        assertNotNull(discoURI2);
-			rmapService.createDiSCO(rmapDisco2, requestAgent);
+			rmapService.createDiSCO(rmapDisco2, requestEventDetails);
 					
 			response = agentResponseManager.getRMapAgentDiSCOs(
 					URLEncoder.encode(TestConstants.SYSAGENT_ID,StandardCharsets.UTF_8.name()),

--- a/api/src/test/java/info/rmapproject/api/responsemgr/DiscoResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/DiscoResponseManagerTest.java
@@ -167,7 +167,7 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 		RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 		String discoURI = rmapDisco.getId().toString();
         assertNotNull(discoURI);
-		rmapService.createDiSCO(rmapDisco, requestAgent);
+		rmapService.createDiSCO(rmapDisco, requestEventDetails);
 	
 		try {
 			response = discoResponseManager.getRMapDiSCO(URLEncoder.encode(discoURI,StandardCharsets.UTF_8.name()),matchingType);
@@ -204,10 +204,10 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 			/*String discoURI = "rmap:rmd18m7p1b";*/
 			
 			//create a disco using the test agent
-			rmapService.createDiSCO(rmapDiscoV1, requestAgent);
+			rmapService.createDiSCO(rmapDiscoV1, requestEventDetails);
 	
 			//update the disco
-			rmapService.updateDiSCO(new URI(discoURI), rmapDiscoV2, requestAgent);
+			rmapService.updateDiSCO(new URI(discoURI), rmapDiscoV2, requestEventDetails);
 			
 	    	Response response=null;
 	    	
@@ -281,10 +281,10 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 		/*String discoURI = "rmap:rmd18m7p1b";*/
 		
 		//create a disco using the test agent
-		rmapService.createDiSCO(rmapDiscoV1, requestAgent);
+		rmapService.createDiSCO(rmapDiscoV1, requestEventDetails);
 
 		//update the disco
-		rmapService.updateDiSCO(new URI(discoURIV1), rmapDiscoV2, requestAgent);
+		rmapService.updateDiSCO(new URI(discoURIV1), rmapDiscoV2, requestEventDetails);
 		
     	Response response=null;
     	
@@ -388,9 +388,9 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 		RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 		assertNotNull(rmapDisco.getId());
 		String strDiscoUri = rmapDisco.getId().toString();
-		rmapService.createDiSCO(rmapDisco, requestAgent);
+		rmapService.createDiSCO(rmapDisco, requestEventDetails);
 		//delete and check status
-		rmapService.deleteDiSCO(new URI(strDiscoUri), requestAgent);
+		rmapService.deleteDiSCO(new URI(strDiscoUri), requestEventDetails);
 		List<URI> rmapEvents = rmapService.getDiSCOEvents(new URI(strDiscoUri));
 		assertTrue(rmapEvents.size()==2);
 		RMapEvent event = rmapService.readEvent(rmapEvents.get(0));
@@ -426,10 +426,10 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
         assertNotNull(discoURIV2);
         
 		//create a disco using the test agent
-		rmapService.createDiSCO(rmapDiscoV1, requestAgent);
+		rmapService.createDiSCO(rmapDiscoV1, requestEventDetails);
 
 		//update the disco
-		rmapService.updateDiSCO(new URI(discoURIV1), rmapDiscoV2, requestAgent);
+		rmapService.updateDiSCO(new URI(discoURIV1), rmapDiscoV2, requestEventDetails);
 		
     	Response response=null;
     		
@@ -474,13 +474,13 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
         assertNotNull(discoURIV3);
         
 		//create a disco using the test agent
-		rmapService.createDiSCO(rmapDiscoV1, requestAgent);
+		rmapService.createDiSCO(rmapDiscoV1, requestEventDetails);
 		TimeUnit.SECONDS.sleep(3);
 		//update the disco
-		rmapService.updateDiSCO(new URI(discoURIV1), rmapDiscoV2, requestAgent);
+		rmapService.updateDiSCO(new URI(discoURIV1), rmapDiscoV2, requestEventDetails);
 		TimeUnit.SECONDS.sleep(3);
 		//update the disco
-		rmapService.updateDiSCO(new URI(discoURIV2), rmapDiscoV3, requestAgent);
+		rmapService.updateDiSCO(new URI(discoURIV2), rmapDiscoV3, requestEventDetails);
 			    		
 		String encodedDiscoUriV1 = URLEncoder.encode(discoURIV1, "UTF-8");
 		String encodedDiscoUriV2 = URLEncoder.encode(discoURIV2, "UTF-8");

--- a/api/src/test/java/info/rmapproject/api/responsemgr/EventResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/EventResponseManagerTest.java
@@ -116,7 +116,7 @@ public class EventResponseManagerTest extends ApiDataCreationTestAbstract {
 		try {			
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			
-			event = (RMapEventCreation) rmapService.createDiSCO(rmapDisco, requestAgent);
+			event = (RMapEventCreation) rmapService.createDiSCO(rmapDisco, requestEventDetails);
 			
 			RMapIri eventUri = event.getId();
 			
@@ -154,7 +154,7 @@ public class EventResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			
 			discoIri = rmapDisco.getId();
-			event = (RMapEventCreation) rmapService.createDiSCO(rmapDisco, requestAgent);
+			event = (RMapEventCreation) rmapService.createDiSCO(rmapDisco, requestEventDetails);
 			
 			RMapIri eventUri = event.getId();
 			

--- a/api/src/test/java/info/rmapproject/api/responsemgr/ResourceResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/ResourceResponseManagerTest.java
@@ -117,7 +117,7 @@ public class ResourceResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco, requestAgent);
+			rmapService.createDiSCO(rmapDisco, requestEventDetails);
 			MultivaluedMap<String,String> params = new MultivaluedHashMap<String, String>();
 			response = resourceResponseManager.getRMapResourceRelatedObjs(TestConstants.TEST_DISCO_DOI, RMapObjectType.OBJECT, NonRdfType.JSON, params);
 
@@ -147,7 +147,7 @@ public class ResourceResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco, requestAgent);
+			rmapService.createDiSCO(rmapDisco, requestEventDetails);
 			
 			MultivaluedMap<String,String> queryparams = new MultivaluedHashMap<String,String>();
 			
@@ -186,10 +186,10 @@ public class ResourceResponseManagerTest extends ApiDataCreationTestAbstract {
 	        assertNotNull(discoURIV2);
 			
 			//create a disco using the test agent
-			rmapService.createDiSCO(rmapDiscoV1, requestAgent);
+			rmapService.createDiSCO(rmapDiscoV1, requestEventDetails);
 
 			//update the disco
-			rmapService.updateDiSCO(new URI(discoURIV1), rmapDiscoV2, requestAgent);
+			rmapService.updateDiSCO(new URI(discoURIV1), rmapDiscoV2, requestEventDetails);
 									
 			MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
 			queryParams.add(Constants.PAGE_PARAM, "1");
@@ -235,7 +235,7 @@ public class ResourceResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco,requestAgent);
+			rmapService.createDiSCO(rmapDisco,requestEventDetails);
 						
 			String testDiscoDoi = URLEncoder.encode(TestConstants.TEST_DISCO_DOI,"UTF-8");
 			MultivaluedMap<String, String> params = new MultivaluedHashMap<String, String>();
@@ -266,7 +266,7 @@ public class ResourceResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco,requestAgent);
+			rmapService.createDiSCO(rmapDisco,requestEventDetails);
 			
 			String resourceUri = URLEncoder.encode(discoURI, StandardCharsets.UTF_8.name());
 			
@@ -319,7 +319,7 @@ public class ResourceResponseManagerTest extends ApiDataCreationTestAbstract {
 		RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML_ENCODED_SPACE_IN_URL);
 		String discoURI = rmapDisco.getId().toString();
 	       assertNotNull(discoURI);
-		rmapService.createDiSCO(rmapDisco, requestAgent);
+		rmapService.createDiSCO(rmapDisco, requestEventDetails);
 					
 		MultivaluedMap<String, String> params = new MultivaluedHashMap<String, String>();
 		params.add(Constants.PAGE_PARAM, "1");
@@ -346,7 +346,7 @@ public class ResourceResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_TURTLE);
 			String discoURI = rmapDisco.getId().toString();
 		    assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco, requestAgent);
+			rmapService.createDiSCO(rmapDisco, requestEventDetails);
 			MultivaluedMap<String, String> params = new MultivaluedHashMap<String, String>();
 			params.add(Constants.PAGE_PARAM, "1");
 			params.add(Constants.LIMIT_PARAM, "10");

--- a/api/src/test/java/info/rmapproject/api/responsemgr/StatementResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/StatementResponseManagerTest.java
@@ -125,7 +125,7 @@ public class StatementResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco, requestAgent);
+			rmapService.createDiSCO(rmapDisco, requestEventDetails);
 			
 			RMapSearchParams params = paramsFactory.newInstance();
 			params.setStatusCode(RMapStatusFilter.ACTIVE);
@@ -161,7 +161,7 @@ public class StatementResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco, requestAgent);
+			rmapService.createDiSCO(rmapDisco, requestEventDetails);
 			
 			RMapSearchParams params = paramsFactory.newInstance();
 			params.setStatusCode(RMapStatusFilter.ACTIVE);
@@ -197,7 +197,7 @@ public class StatementResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco, requestAgent);
+			rmapService.createDiSCO(rmapDisco, requestEventDetails);
 
 			MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
 			response = 
@@ -226,7 +226,7 @@ public class StatementResponseManagerTest extends ApiDataCreationTestAbstract {
 			RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
-			rmapService.createDiSCO(rmapDisco, requestAgent);
+			rmapService.createDiSCO(rmapDisco, requestEventDetails);
 
 			MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
 			response = 

--- a/api/src/test/java/info/rmapproject/api/service/ResourceApiServiceTest.java
+++ b/api/src/test/java/info/rmapproject/api/service/ResourceApiServiceTest.java
@@ -65,7 +65,7 @@ public class ResourceApiServiceTest extends ApiDataCreationTestAbstract{
 		RMapDiSCO rmapDisco = TestUtils.getRMapDiSCO(TestFile.DISCOA_XML);
 		String discoURI = rmapDisco.getId().toString();
 		assertNotNull(discoURI);
-		rmapService.createDiSCO(rmapDisco,requestAgent);
+		rmapService.createDiSCO(rmapDisco,requestEventDetails);
 
 		String resourceUri = URLEncoder.encode(discoURI, StandardCharsets.UTF_8.name());
 		HttpHeaders httpheaders = mock(HttpHeaders.class);

--- a/auth/src/main/java/info/rmapproject/auth/service/UserRMapAgentServiceImpl.java
+++ b/auth/src/main/java/info/rmapproject/auth/service/UserRMapAgentServiceImpl.java
@@ -44,7 +44,7 @@ import info.rmapproject.core.model.agent.RMapAgent;
 import info.rmapproject.core.model.event.RMapEvent;
 import info.rmapproject.core.model.impl.openrdf.ORAdapter;
 import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rmapservice.RMapService;
 
 /**
@@ -107,22 +107,26 @@ public class UserRMapAgentServiceImpl {
 				apiKeyUri = new URI(sApiKeyUri);
 			}
 						
-			RMapRequestAgent reqAgent  = new RMapRequestAgent(agentId, apiKeyUri);
-			LOG.debug("RMapRequestAgent instantiated with agentId: {} and apiKeyUri: {}", agentId, (apiKeyUri==null ? "" : apiKeyUri));
-
+			RequestEventDetails reqEventDetails  = new RequestEventDetails(agentId, apiKeyUri);
+			LOG.debug("RequestEventDetails instantiated with agentId: {} and apiKeyUri: {}", agentId, (apiKeyUri==null ? "" : apiKeyUri));
+			
 			//if agent isn't in the triplestore, create it!  otherwise, update it
 			if (rmapService.isAgentId(agentId)){
 				//rmap agent exists - but has there been a change?
 				RMapAgent origAgent = rmapService.readAgent(agentId);
 				if (!origAgent.equals(agent)){	
 					//something has changed, do update
-					event = rmapService.updateAgent(agent, reqAgent);	
+					if (user.getUserId()>0) {
+						reqEventDetails.setDescription("Agent updated from user record");
+					}
+					event = rmapService.updateAgent(agent, reqEventDetails);	
 					LOG.info("rmap:Agent ID {} was updated in RMap using the latest User record information", agent.getId());
 				}				
 			}
 			else { 
+				reqEventDetails.setDescription("Agent created from user record");
 				//id generated but no record created yet - create agent
-				event = rmapService.createAgent(agent, reqAgent);	
+				event = rmapService.createAgent(agent, reqEventDetails);	
 				LOG.info("rmap:Agent ID {} was created for the first time in RMap", agent.getId());			
 			}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
@@ -43,7 +43,7 @@ import info.rmapproject.core.model.RMapValue;
 import info.rmapproject.core.model.event.RMapEvent;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.utils.DateUtils;
 import info.rmapproject.core.vocabulary.impl.openrdf.PROV;
 import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
@@ -136,46 +136,33 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
-	protected ORMapEvent(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType) throws RMapException, RMapDefectiveArgumentException {
+	protected ORMapEvent(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType) throws RMapException, RMapDefectiveArgumentException {
 		this(id);
-		if (associatedAgent==null){
+		if (reqEventDetails==null){
 			throw new RMapException("Null agent not allowed in RMapEvent");
 		}
 		if (targetType==null){
 			throw new RMapException("Null target type not allowed in RMapEvent");
 		}
-		URI systemAgentUri = associatedAgent.getSystemAgent();
+		URI systemAgentUri = reqEventDetails.getSystemAgent();
 		if (systemAgentUri==null){
 			throw new RMapException("Null agent not allowed in RMapEvent");
 		}		
 		this.setAssociatedAgentStatement(ORAdapter.uri2OpenRdfIri(systemAgentUri));
 		
-		URI agentKeyUri = associatedAgent.getAgentKeyId();
+		URI agentKeyUri = reqEventDetails.getAgentKeyId();
 		if (agentKeyUri!=null){
 			this.setAssociatedKeyStatement(ORAdapter.uri2OpenRdfIri(agentKeyUri));
 		}
+
+		RMapValue description = reqEventDetails.getDescription();
+		if (agentKeyUri!=null){
+			this.setDescription(description);	
+		}
+		
 		this.setEventTargetTypeStatement(targetType);	
 	}
-	
-	/**
-	 * Instantiates a new ORMapEvent.
-	 *
-	 * @param associatedAgent the associated agent
-	 * @param targetType the target type
-	 * @param desc the desc
-	 * @throws RMapException the RMap exception
-	 * @throws RMapDefectiveArgumentException the RMap defective argument exception
-	 */
-	protected ORMapEvent(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, RMapValue desc)
-			throws RMapException, RMapDefectiveArgumentException {
-		this(id, associatedAgent, targetType);
-		if (desc != null){
-			Statement descSt = ORAdapter.getValueFactory().createStatement(this.context, 
-					DC.DESCRIPTION, ORAdapter.rMapValue2OpenRdfValue(desc), this.context);
-			this.descriptionStmt = descSt;
-		}
-	}	
-	
+		
 	/**
 	 * Sets the statement containing the event type.
 	 *
@@ -461,7 +448,6 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 			this.descriptionStmt = descSt;
 		}
 	}
-	
 	
 	/**
 	 * Gets the DiSCO's context i.e. the DiSCO's graphId.

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreation.java
@@ -22,19 +22,18 @@
  */
 package info.rmapproject.core.model.impl.openrdf;
 
+import java.util.List;
+
+import org.openrdf.model.IRI;
+import org.openrdf.model.Statement;
+
 import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.model.RMapIri;
-import info.rmapproject.core.model.RMapValue;
 import info.rmapproject.core.model.event.RMapEventCreation;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
-
-import java.util.List;
-
-import org.openrdf.model.Statement;
-import org.openrdf.model.IRI;
+import info.rmapproject.core.model.request.RequestEventDetails;
 
 /**
  * The concrete class representing the Creation Event for the openrdf implementation of RMap
@@ -88,25 +87,9 @@ public class ORMapEventCreation extends ORMapEventWithNewObjects implements RMap
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException the RMap defective argument exception
 	 */
-	public ORMapEventCreation(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType)
+	public ORMapEventCreation(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType)
 			throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType);
-		this.setEventTypeStatement(RMapEventType.CREATION);
-	}
-	
-
-	/**
-	 * Instantiates a new RMap Creation Event
-	 *
-	 * @param associatedAgent the associated agent
-	 * @param targetType the target type
-	 * @param desc the desc
-	 * @throws RMapException the RMap exception
-	 * @throws RMapDefectiveArgumentException the RMap defective argument exception
-	 */
-	public ORMapEventCreation(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, RMapValue desc)
-			throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType, desc);
+		super(id, reqEventDetails, targetType);
 		this.setEventTypeStatement(RMapEventType.CREATION);
 	}
 	
@@ -115,15 +98,13 @@ public class ORMapEventCreation extends ORMapEventWithNewObjects implements RMap
 	 *
 	 * @param associatedAgent the associated agent
 	 * @param targetType the target type
-	 * @param desc the description
 	 * @param createdObjIds the list of IRIs for created objects
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException the RMap defective argument exception
 	 */
-	public ORMapEventCreation(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, RMapValue desc, List<RMapIri> createdObjIds)
+	public ORMapEventCreation(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType, List<RMapIri> createdObjIds)
 		throws RMapException, RMapDefectiveArgumentException{
-		this(id, associatedAgent, targetType, desc);
-		this.setEventTypeStatement(RMapEventType.CREATION);
+		this(id, reqEventDetails, targetType);
 		this.setCreatedObjectIds(createdObjIds);	
 	}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
@@ -29,11 +29,10 @@ import org.openrdf.model.Statement;
 import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.model.RMapIri;
-import info.rmapproject.core.model.RMapValue;
 import info.rmapproject.core.model.event.RMapEventDeletion;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 
 /**
@@ -90,16 +89,14 @@ public class ORMapEventDeletion extends ORMapEvent implements RMapEventDeletion 
 	/**
 	 * Instantiates a new RMap Deletion Event
 	 *
-	 * @param associatedAgent the associated agent
+	 * @param reqEventDetails client provided event details
 	 * @param targetType the target type
-	 * @param desc the desc
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException the RMap defective argument exception
 	 */
-	public ORMapEventDeletion(IRI id, RMapRequestAgent associatedAgent,
-			RMapEventTargetType targetType, RMapValue desc)
+	public ORMapEventDeletion(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType)
 			throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType, desc);
+		super(id, reqEventDetails, targetType);
 		this.setEventTypeStatement(RMapEventType.DELETION);
 	}
 	

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
@@ -36,7 +36,7 @@ import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.event.RMapEventDerivation;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 
 /**
@@ -76,9 +76,9 @@ public class ORMapEventDerivation extends ORMapEventWithNewObjects implements
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
-	public ORMapEventDerivation(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, IRI sourceObject, IRI derivedObject)
+	public ORMapEventDerivation(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType, IRI sourceObject, IRI derivedObject)
 	throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType);
+		super(id, reqEventDetails, targetType);
 		this.setEventTypeStatement(RMapEventType.DERIVATION);
 		this.setSourceObjectStmt(sourceObject);
 		this.setDerivationStmt(derivedObject);

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
@@ -29,7 +29,7 @@ import info.rmapproject.core.model.RMapValue;
 import info.rmapproject.core.model.event.RMapEventInactivation;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 
 import org.openrdf.model.IRI;
@@ -97,23 +97,8 @@ public class ORMapEventInactivation extends ORMapEvent implements
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
-	public ORMapEventInactivation(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType) throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType);
-		this.setEventTypeStatement(RMapEventType.INACTIVATION);
-	}
-
-	/**
-	 * Instantiates a new RMap Inactivation Event
-	 *
-	 * @param associatedAgent the associated agent
-	 * @param targetType the target type
-	 * @param desc the desc
-	 * @throws RMapException the RMap exception
-	 * @throws RMapDefectiveArgumentException the RMap defective argument exception
-	 */
-	public ORMapEventInactivation(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, RMapValue desc)
-			throws RMapException, RMapDefectiveArgumentException  {
-		super(id, associatedAgent, targetType, desc);
+	public ORMapEventInactivation(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType) throws RMapException, RMapDefectiveArgumentException {
+		super(id, reqEventDetails, targetType);
 		this.setEventTypeStatement(RMapEventType.INACTIVATION);
 	}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
@@ -32,7 +32,7 @@ import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventTombstone;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 
 /**
@@ -93,8 +93,8 @@ public class ORMapEventTombstone extends ORMapEvent implements
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
-	public ORMapEventTombstone(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, IRI tombstonedResource) throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType);
+	public ORMapEventTombstone(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType, IRI tombstonedResource) throws RMapException, RMapDefectiveArgumentException {
+		super(id, reqEventDetails, targetType);
 		this.setEventTypeStatement(RMapEventType.TOMBSTONE);
 		this.setTombstonedResourceIdStmt(tombstonedResource);
 	}

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
@@ -36,7 +36,7 @@ import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
 import info.rmapproject.core.model.event.RMapEventUpdate;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 
 /**
@@ -113,9 +113,9 @@ public class ORMapEventUpdate extends ORMapEventWithNewObjects implements RMapEv
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
-	public ORMapEventUpdate(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, IRI inactivatedObject, IRI derivedObject)
+	public ORMapEventUpdate(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType, IRI inactivatedObject, IRI derivedObject)
 	throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType);
+		super(id, reqEventDetails, targetType);
 		this.setEventTypeStatement(RMapEventType.UPDATE);
 		this.setInactivatedObjectStmt(inactivatedObject);
 		this.setDerivationStmt(derivedObject);

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
@@ -32,7 +32,7 @@ import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
 import info.rmapproject.core.model.event.RMapEventUpdateWithReplace;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 
 /**
@@ -92,8 +92,8 @@ public class ORMapEventUpdateWithReplace extends ORMapEvent implements RMapEvent
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
-	public ORMapEventUpdateWithReplace(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType) throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType);
+	public ORMapEventUpdateWithReplace(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType) throws RMapException, RMapDefectiveArgumentException {
+		super(id, reqEventDetails, targetType);
 		this.setEventTypeStatement(RMapEventType.REPLACE);
 	}
 	
@@ -106,9 +106,9 @@ public class ORMapEventUpdateWithReplace extends ORMapEvent implements RMapEvent
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException the RMap defective argument exception
 	 */
-	public ORMapEventUpdateWithReplace(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, IRI updateObjectId)
+	public ORMapEventUpdateWithReplace(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType, IRI updateObjectId)
 				throws RMapException, RMapDefectiveArgumentException {
-		this(id, associatedAgent, targetType);
+		this(id, reqEventDetails, targetType);
 		this.setUpdatedObjectId(ORAdapter.openRdfIri2RMapIri(updateObjectId));
 		
 	}

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
@@ -26,17 +26,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.openrdf.model.IRI;
 import org.openrdf.model.Model;
 import org.openrdf.model.Statement;
-import org.openrdf.model.IRI;
 
 import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.model.RMapIri;
-import info.rmapproject.core.model.RMapValue;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventWithNewObjects;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.vocabulary.impl.openrdf.PROV;
 
 /**
@@ -93,22 +92,8 @@ public abstract class ORMapEventWithNewObjects extends ORMapEvent implements
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
-	protected ORMapEventWithNewObjects(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType) throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType);
-	}
-
-	/**
-	 * Instantiates a new RMap Event in which new objects were created.
-	 *
-	 * @param associatedAgent the associated agent
-	 * @param targetType the target type
-	 * @param desc the desc
-	 * @throws RMapException the RMap exception
-	 * @throws RMapDefectiveArgumentException the RMap defective argument exception
-	 */
-	protected ORMapEventWithNewObjects(IRI id, RMapRequestAgent associatedAgent, RMapEventTargetType targetType, RMapValue desc)
-			throws RMapException, RMapDefectiveArgumentException {
-		super(id, associatedAgent, targetType, desc);
+	protected ORMapEventWithNewObjects(IRI id, RequestEventDetails reqEventDetails, RMapEventTargetType targetType) throws RMapException, RMapDefectiveArgumentException {
+		super(id, reqEventDetails, targetType);
 	}
 
 	/* (non-Javadoc)

--- a/core/src/main/java/info/rmapproject/core/model/request/RequestEventDetails.java
+++ b/core/src/main/java/info/rmapproject/core/model/request/RequestEventDetails.java
@@ -19,33 +19,41 @@
  *******************************************************************************/
 package info.rmapproject.core.model.request;
 
-import info.rmapproject.core.exception.RMapException;
-
 import java.io.Serializable;
 import java.net.URI;
 
+import info.rmapproject.core.exception.RMapException;
+import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.RMapLiteral;
+import info.rmapproject.core.model.RMapValue;
+
 /**
- * Used to manage requesting agent properties that are relevant to the request
- * for use when creating provenance information.
+ * Used to manage properties that will be added to the Event when the RMap database is updated.
+ * Specifically the Agent responsible for the change, a key ID to associate with the Event
+ * and a free-text Event description
  *
  * @author khanson
  */
-public class RMapRequestAgent implements Serializable {
+public class RequestEventDetails implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	/** The system agent. */
+	/** The system agent that will be referenced in the Event (eventUri-prov:associatedWith-systemAgent). */
 	URI systemAgent;
 	
-	/** The agent key URI. */
+	/** The agent key URI to go into the Event (eventUri-prov:used-agentKeyId). */
 	URI agentKeyId = null;
+	
+	/** Description to go into Event (eventUri-dct:description-description) */
+	RMapValue description = null;
+	
 	
 	/**
 	 * Instantiates a new RMap request agent.
 	 *
 	 * @param systemAgent the system agent URI
 	 */
-	public RMapRequestAgent(URI systemAgent) throws RMapException{
+	public RequestEventDetails(URI systemAgent) throws RMapException{
 		if (systemAgent == null){
 			throw new RMapException("Requesting System Agent cannot be null.");
 		}
@@ -58,7 +66,7 @@ public class RMapRequestAgent implements Serializable {
 	 * @param systemAgent the system agent URI
 	 * @param agentKeyId the agent key URI - null if none specified
 	 */
-	public RMapRequestAgent(URI systemAgent, URI agentKeyId) throws RMapException{
+	public RequestEventDetails(URI systemAgent, URI agentKeyId) throws RMapException{
 		if (systemAgent == null){
 			throw new RMapException("Requesting System Agent cannot be null.");
 		}
@@ -102,21 +110,59 @@ public class RMapRequestAgent implements Serializable {
 		this.agentKeyId = agentKeyId;
 	}
 
+	/**
+	 * Gets the description that will be added to the Event
+	 * @return description
+	 */
+	public RMapValue getDescription() {
+		return description;
+	}
+	
+	/**
+	 * Sets the description to go into the Event
+	 * @param description
+	 */
+	public void setDescription(RMapValue description) {
+		this.description = description;
+	}
+	
+	/**
+	 * Sets the description to go into the Event - converts string to RMapValue 
+	 * @param description
+	 */
+	public void setDescription(String description) {
+		if (description!=null){
+			RMapValue rDescription = null;
+			try {
+				URI testUri = new URI(description);
+				rDescription = new RMapIri(testUri);
+			} catch (Exception ex){
+				rDescription = new RMapLiteral(description);
+			}
+			this.setDescription(rDescription);
+		} else {
+			RMapValue nulldesc = null;
+			this.setDescription(nulldesc);
+		}
+	}	
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 
-		RMapRequestAgent that = (RMapRequestAgent) o;
+		RequestEventDetails that = (RequestEventDetails) o;
 
 		if (systemAgent != null ? !systemAgent.equals(that.systemAgent) : that.systemAgent != null) return false;
-		return agentKeyId != null ? agentKeyId.equals(that.agentKeyId) : that.agentKeyId == null;
+		if (agentKeyId != null ? !agentKeyId.equals(that.agentKeyId) : that.agentKeyId != null) return false;
+		return description != null ? description.equals(that.description) : that.description == null;
 	}
 
 	@Override
 	public int hashCode() {
 		int result = systemAgent != null ? systemAgent.hashCode() : 0;
 		result = 31 * result + (agentKeyId != null ? agentKeyId.hashCode() : 0);
+		result = 31 * result + (description != null ? description.hashCode() : 0);
 		return result;
 	}
 
@@ -125,6 +171,7 @@ public class RMapRequestAgent implements Serializable {
 		return "RMapRequestAgent{" +
 				"systemAgent=" + systemAgent +
 				", agentKeyId=" + agentKeyId +
+				", description=" + description +
 				'}';
 	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/request/RequestEventDetails.java
+++ b/core/src/main/java/info/rmapproject/core/model/request/RequestEventDetails.java
@@ -49,7 +49,7 @@ public class RequestEventDetails implements Serializable {
 	
 	
 	/**
-	 * Instantiates a new RMap request agent.
+	 * Instantiates a new RMap event details object with System Agent only
 	 *
 	 * @param systemAgent the system agent URI
 	 */
@@ -61,7 +61,7 @@ public class RequestEventDetails implements Serializable {
 	}
 	
 	/**
-	 * Instantiates a new RMap request agent.
+	 * Instantiates a new RMap event details object with System Agent and KeyId
 	 *
 	 * @param systemAgent the system agent URI
 	 * @param agentKeyId the agent key URI - null if none specified
@@ -72,6 +72,22 @@ public class RequestEventDetails implements Serializable {
 		}
 		this.systemAgent = systemAgent;
 		this.agentKeyId = agentKeyId; //null ok
+	}
+		
+	/**
+	 * Instantiates a new RMap event details object with all properties
+	 *
+	 * @param systemAgent the system agent URI
+	 * @param agentKeyId the agent key URI - null if none specified
+	 * @param description the description to be applied to the Event	 
+	 */
+	public RequestEventDetails(URI systemAgent, URI agentKeyId, String description) throws RMapException{
+		if (systemAgent == null){
+			throw new RMapException("Requesting System Agent cannot be null.");
+		}
+		this.systemAgent = systemAgent;
+		this.agentKeyId = agentKeyId; //null ok
+		setDescription(description);
 	}
 	
 	/**

--- a/core/src/main/java/info/rmapproject/core/model/request/RequestEventDetails.java
+++ b/core/src/main/java/info/rmapproject/core/model/request/RequestEventDetails.java
@@ -81,7 +81,7 @@ public class RequestEventDetails implements Serializable {
 	 * @param agentKeyId the agent key URI - null if none specified
 	 * @param description the description to be applied to the Event	 
 	 */
-	public RequestEventDetails(URI systemAgent, URI agentKeyId, String description) throws RMapException{
+	public RequestEventDetails(URI systemAgent, URI agentKeyId, RMapValue description) throws RMapException{
 		if (systemAgent == null){
 			throw new RMapException("Requesting System Agent cannot be null.");
 		}

--- a/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
@@ -37,7 +37,7 @@ import info.rmapproject.core.model.RMapValue;
 import info.rmapproject.core.model.agent.RMapAgent;
 import info.rmapproject.core.model.disco.RMapDiSCO;
 import info.rmapproject.core.model.event.RMapEvent;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.model.request.RMapSearchParams;
 import info.rmapproject.core.model.request.ResultBatch;
 
@@ -180,13 +180,13 @@ public interface RMapService {
 	/**
 	 * Creates a new DiSCO and returns the creation Event
 	 *
-	 * @param disco the new DiSCO
-	 * @param requestAgent the agent requesting the create
+	 * @param disco the new DiSCOreqEventDetails
+	 * @param reqEventDetails client provided event information - contains requesting agent, event description and key uri
 	 * @return an RMap Event
 	 * @throws RMapException an RMapException
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public RMapEvent createDiSCO(RMapDiSCO disco, RMapRequestAgent requestAgent)  throws RMapException, RMapDefectiveArgumentException;
+	public RMapEvent createDiSCO(RMapDiSCO disco, RequestEventDetails reqEventDetails)  throws RMapException, RMapDefectiveArgumentException;
 
 	/**
 	 * Gets the DiSCO's current status.
@@ -206,25 +206,25 @@ public interface RMapService {
 	 *
 	 * @param oldDiscoId the original DiSCO URI
 	 * @param disco the updated DiSCO
-	 * @param requestAgent the requesting agent
+	 * @param reqEventDetails client provided event information - contains requesting agent, event description and key uri
 	 * @return an RMap Event
 	 * @throws RMapException an RMapException
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public RMapEvent updateDiSCO(URI oldDiscoId, RMapDiSCO disco, RMapRequestAgent requestAgent) 
+	public RMapEvent updateDiSCO(URI oldDiscoId, RMapDiSCO disco, RequestEventDetails reqEventDetails) 
 			throws RMapException, RMapDefectiveArgumentException;
 	
 	/**
 	 * Inactivate a DiSCO.  Can only be performed by same agent that created DiSCO.
 	 *
 	 * @param oldDiscoId the original DiSCO URI
-	 * @param requestAgent the requesting agent
+	 * @param reqEventDetails client provided event information - contains requesting agent, event description and key uri
 	 * @return an RMap Event
 	 * @throws RMapException an RMapException
 	 * @throws RMapDiSCONotFoundException an RMapDiSCO not found exception
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public RMapEvent inactivateDiSCO(URI oldDiscoId, RMapRequestAgent requestAgent) throws RMapException, RMapDiSCONotFoundException,
+	public RMapEvent inactivateDiSCO(URI oldDiscoId, RequestEventDetails reqEventDetails) throws RMapException, RMapDiSCONotFoundException,
 	RMapDefectiveArgumentException;
 	
 
@@ -232,12 +232,12 @@ public interface RMapService {
 	 * Soft delete (tombstone) of a DiSCO.  Can only be performed by same agent that created DiSCO.
 	 *
 	 * @param discoID the URI of the DiSCO to be tombstoned
-	 * @param requestAgent the requesting agent
+	 * @param reqEventDetails client provided event information - contains requesting agent, event description and key uri
 	 * @return an RMap Event
 	 * @throws RMapException an RMapException
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public RMapEvent deleteDiSCO (URI discoID, RMapRequestAgent requestAgent) throws RMapException, RMapDefectiveArgumentException;
+	public RMapEvent deleteDiSCO (URI discoID, RequestEventDetails reqEventDetails) throws RMapException, RMapDefectiveArgumentException;
 
 	/**
 	 * Get all versions of a DiSCO whether created by original creator of DiSCO or by some
@@ -378,12 +378,12 @@ public interface RMapService {
 	 * - in other words agents typically create their own record if they registered through the GUI.  
 	 *
 	 * @param agent RMapAgent object to be instantiated in system
-	 * @param requestAgent agent creating this new Agent
+	 * @param reqEventDetails client provided event information - contains requesting agent, event description and key uri
 	 * @return RMapEvent associated with creation of Agent
 	 * @throws RMapException an RMapException
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public RMapEvent createAgent(RMapAgent agent, RMapRequestAgent requestAgent) throws RMapException, RMapDefectiveArgumentException;
+	public RMapEvent createAgent(RMapAgent agent, RequestEventDetails reqEventDetails) throws RMapException, RMapDefectiveArgumentException;
 	
 	/**
 	 * Create a new agent using the agent properties. Note: In most instances the agentID should match the URI in requesting Agent
@@ -393,12 +393,12 @@ public interface RMapService {
 	 * @param name the name of the new Agent as a string
 	 * @param identityProvider the URI of the Identity Provider used to validate the new Agent
 	 * @param authKeyUri the Auth Key URI of the new Agent
-	 * @param requestAgent the Agent requesting the creation
+	 * @param reqEventDetails client provided event information - contains requesting agent, event description and key uri
 	 * @return an RMap Event
 	 * @throws RMapException an RMapException
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public RMapEvent createAgent(URI agentID, String name, URI identityProvider, URI authKeyUri, RMapRequestAgent requestAgent) throws RMapException, RMapDefectiveArgumentException;
+	public RMapEvent createAgent(URI agentID, String name, URI identityProvider, URI authKeyUri, RequestEventDetails reqEventDetails) throws RMapException, RMapDefectiveArgumentException;
 	
 	/**
 	 * Create a new Agent using name, identity provider, and auth key URI. In this method, the requesting Agent
@@ -419,12 +419,12 @@ public interface RMapService {
 	 * Agent
 	 *
 	 * @param agent updated RMap Agent object
-	 * @param requestAgent Agent requesting the update
+	 * @param reqEventDetails client provided event information - contains requesting agent, event description and key uri
 	 * @return RMapEvent associated with creation of Agent
 	 * @throws RMapException an RMapException
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public RMapEvent updateAgent(RMapAgent agent, RMapRequestAgent requestAgent) throws RMapException, RMapDefectiveArgumentException;
+	public RMapEvent updateAgent(RMapAgent agent, RequestEventDetails reqEventDetails) throws RMapException, RMapDefectiveArgumentException;
 	
 	/**
 	 * Update an existing Agent. Typically the Agent being updated will be the same as the requesting
@@ -434,12 +434,12 @@ public interface RMapService {
 	 * @param name the Agent's new name
 	 * @param identityProvider the updated URI for the Identity Provider 
 	 * @param authKeyUri the updated auth key uri
-	 * @param requestAgent the requesting Agent
+	 * @param reqEventDetails client provided event information - contains requesting agent, event description and key uri
 	 * @return an RMap Event
 	 * @throws RMapException an RMapException
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public RMapEvent updateAgent(URI agentID, String name, URI identityProvider, URI authKeyUri, RMapRequestAgent requestAgent) throws RMapException, RMapDefectiveArgumentException;
+	public RMapEvent updateAgent(URI agentID, String name, URI identityProvider, URI authKeyUri, RequestEventDetails reqEventDetails) throws RMapException, RMapDefectiveArgumentException;
 	
 	/**
 	 * Retrieves a list of Events that affected the Agent record.

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
@@ -58,7 +58,7 @@ import info.rmapproject.core.model.event.RMapEvent;
 import info.rmapproject.core.model.impl.openrdf.ORAdapter;
 import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
 import info.rmapproject.core.model.impl.openrdf.ORMapDiSCO;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.model.request.RMapSearchParams;
 import info.rmapproject.core.model.request.RMapSearchParamsFactory;
 import info.rmapproject.core.model.request.ResultBatch;
@@ -351,19 +351,19 @@ public class ORMapService implements RMapService {
 	 * @see info.rmapproject.core.rmapservice.RMapService#createDiSCO(java.net.URI, RMapDiSCO)
 	 */
 	@Override
-	public RMapEvent createDiSCO(RMapDiSCO disco, RMapRequestAgent requestAgent)
+	public RMapEvent createDiSCO(RMapDiSCO disco, RequestEventDetails reqEventDetails)
 			throws RMapException, RMapDefectiveArgumentException {
 		if (disco==null){
 			throw new RMapDefectiveArgumentException("Null DiSCO provided");
 		}
-		if (requestAgent==null){
-			throw new RMapDefectiveArgumentException("Null Agent id provided");
+		if (reqEventDetails==null){
+			throw new RMapDefectiveArgumentException("Null reqEventDetails provided");
 		}
 		if (!(disco instanceof ORMapDiSCO)){
 			throw new RMapDefectiveArgumentException("disco not instance of ORMapDiSCO");
 		}
 		try {
-			RMapEvent createEvent = discomgr.createDiSCO((ORMapDiSCO)disco, requestAgent, triplestore);
+			RMapEvent createEvent = discomgr.createDiSCO((ORMapDiSCO)disco, reqEventDetails, triplestore);
 			return createEvent;			
 		} finally {
 			closeConnection();
@@ -388,13 +388,13 @@ public class ORMapService implements RMapService {
 	}
 	
 	/* (non-Javadoc)
-	 * @see info.rmapproject.core.rmapservice.RMapService#updateDiSCO(java.net.URI, java.net.URI, RMapDiSCO, java.net.URI)
+	 * @see info.rmapproject.core.rmapservice.RMapService#updateDiSCO(java.net.URI, java.net.URI, RMapDiSCO, RequestEventDetails)
 	 */
 	@Override
-	public RMapEvent updateDiSCO(URI oldDiscoId, RMapDiSCO disco, RMapRequestAgent requestAgent)
+	public RMapEvent updateDiSCO(URI oldDiscoId, RMapDiSCO disco, RequestEventDetails reqEventDetails)
 			throws RMapException, RMapDefectiveArgumentException {
-		if (requestAgent==null){
-			throw new RMapDefectiveArgumentException ("Null system agent");
+		if (reqEventDetails==null){
+			throw new RMapDefectiveArgumentException ("Null reqEventDetails");
 		}
 		if (oldDiscoId==null){
 			throw new RMapDefectiveArgumentException ("Null id for old DiSCO");
@@ -411,7 +411,7 @@ public class ORMapService implements RMapService {
 			updateEvent = discomgr.updateDiSCO(
 										uri2OpenRdfIri(oldDiscoId),
 										(ORMapDiSCO)disco, 
-										requestAgent,
+										reqEventDetails,
 										false, 
 										triplestore);
 		} catch (RMapException | RMapDefectiveArgumentException ex) {
@@ -433,18 +433,18 @@ public class ORMapService implements RMapService {
 	 * @see info.rmapproject.core.rmapservice.RMapService#inactivateDiSCO(java.net.URI, java.net.URI)
 	 */
 	@Override
-	public RMapEvent inactivateDiSCO(URI oldDiscoId, RMapRequestAgent requestAgent)
+	public RMapEvent inactivateDiSCO(URI oldDiscoId, RequestEventDetails reqEventDetails)
 			throws RMapException, RMapDiSCONotFoundException,
 			RMapDefectiveArgumentException {
 		if (oldDiscoId==null){
 			throw new RMapDefectiveArgumentException ("Null id for old DiSCO");
 		}
-		if (requestAgent==null){
-			throw new RMapDefectiveArgumentException ("Null system agent");
+		if (reqEventDetails==null){
+			throw new RMapDefectiveArgumentException ("Null reqEventDetails");
 		}
 		RMapEvent inactivateEvent = null;
 		try {
-			inactivateEvent = discomgr.updateDiSCO(uri2OpenRdfIri(oldDiscoId), null, requestAgent, true, triplestore);
+			inactivateEvent = discomgr.updateDiSCO(uri2OpenRdfIri(oldDiscoId), null, reqEventDetails, true, triplestore);
 		} catch (RMapException | RMapDefectiveArgumentException ex) {
 			try {
 				//there has been an error during an update so try to rollback the transaction
@@ -463,17 +463,17 @@ public class ORMapService implements RMapService {
 	 * @see info.rmapproject.core.rmapservice.RMapService#deleteDiSCO(java.net.URI, java.net.URI)
 	 */
 	@Override
-	public RMapEvent deleteDiSCO(URI discoID, RMapRequestAgent requestAgent) 
+	public RMapEvent deleteDiSCO(URI discoID, RequestEventDetails reqEventDetails) 
 			throws RMapException, RMapDefectiveArgumentException {
 		if (discoID ==null){
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
 		}
-		if (requestAgent==null){
-			throw new RMapDefectiveArgumentException ("Null system agent");
+		if (reqEventDetails==null){
+			throw new RMapDefectiveArgumentException ("Null reqEventDetails");
 		}
 		RMapEvent tombstoneEvent = null;
 		try {
-			tombstoneEvent = discomgr.tombstoneDiSCO(uri2OpenRdfIri(discoID), requestAgent, triplestore);
+			tombstoneEvent = discomgr.tombstoneDiSCO(uri2OpenRdfIri(discoID), reqEventDetails, triplestore);
 		} catch (RMapException ex) {
 			try {
 				//there has been an error during an update so try to rollback the transaction
@@ -732,7 +732,7 @@ public class ORMapService implements RMapService {
 	 * @see info.rmapproject.core.rmapservice.RMapService#readAgent(RMapAgent, java.net.URI)
 	 */
 	@Override
-	public RMapEvent createAgent(RMapAgent agent, RMapRequestAgent requestAgent) 
+	public RMapEvent createAgent(RMapAgent agent, RequestEventDetails reqEventDetails) 
 			throws RMapException, RMapDefectiveArgumentException {
 		if (agent==null){
 			throw new RMapDefectiveArgumentException("Null agent");
@@ -740,13 +740,13 @@ public class ORMapService implements RMapService {
 		if (!(agent instanceof ORMapAgent)){
 			throw new RMapDefectiveArgumentException("unrecognized type for agent");
 		}
-		if (requestAgent==null){
-			throw new RMapDefectiveArgumentException("Null system agent");
+		if (reqEventDetails==null){
+			throw new RMapDefectiveArgumentException("Null reqEventDetails");
 		}
 		RMapEvent event = null;
 		try {
 			ORMapAgent orAgent = (ORMapAgent)agent;
-			event = agentmgr.createAgent(orAgent, requestAgent, triplestore);
+			event = agentmgr.createAgent(orAgent, reqEventDetails, triplestore);
 		} catch (RMapException ex) {
 			try {
 				//there has been an error during an update so try to rollback the transaction
@@ -766,7 +766,7 @@ public class ORMapService implements RMapService {
 	 * @see info.rmapproject.core.rmapservice.RMapService#createAgent(java.net.URI, String, java.net.URI, java.net.URI, java.net.URI)
 	 */
 	@Override
-	public RMapEvent createAgent(URI agentID, String name, URI identityProvider, URI authKeyUri, RMapRequestAgent requestAgent) 
+	public RMapEvent createAgent(URI agentID, String name, URI identityProvider, URI authKeyUri, RequestEventDetails reqEventDetails) 
 			throws RMapException, RMapDefectiveArgumentException {
 		if (agentID==null){
 			throw new RMapDefectiveArgumentException("Null Agent ID");
@@ -780,8 +780,8 @@ public class ORMapService implements RMapService {
 		if (authKeyUri==null){
 			throw new RMapDefectiveArgumentException("Null Agent authorization ID");
 		}
-		if (requestAgent==null){
-			throw new RMapDefectiveArgumentException("Null system agent");
+		if (reqEventDetails==null){
+			throw new RMapDefectiveArgumentException("Null reqEventDetails");
 		}
 				
 		Value nameValue = ORAdapter.getValueFactory().createLiteral(name);
@@ -789,7 +789,7 @@ public class ORMapService implements RMapService {
 		IRI oIdentityProvider = uri2OpenRdfIri(identityProvider);
 		IRI oAuthKeyUri = uri2OpenRdfIri(authKeyUri);
 		RMapAgent agent = new ORMapAgent(oAgentId, oIdentityProvider, oAuthKeyUri, nameValue);
-		RMapEvent event = createAgent(agent, requestAgent);
+		RMapEvent event = createAgent(agent, reqEventDetails);
 		return event;
 	}
 
@@ -815,8 +815,8 @@ public class ORMapService implements RMapService {
 			IRI rIdentityProvider = uri2OpenRdfIri(identityProvider);
 			IRI rAuthKeyUri = uri2OpenRdfIri(authKeyUri);
 			RMapAgent agent = new ORMapAgent(uri2OpenRdfIri(idService.createId()), rIdentityProvider, rAuthKeyUri, rName);
-			RMapRequestAgent requestAgent = new RMapRequestAgent(new URI(agent.getId().toString()));
-			event = createAgent(agent, requestAgent);
+			RequestEventDetails reqEventDetails = new RequestEventDetails(new URI(agent.getId().toString()));
+			event = createAgent(agent, reqEventDetails);
 		} catch (URISyntaxException e) {
 			throw new RMapException("Could not convert Agent Id to URI", e);
 		} catch (Exception e) {
@@ -832,7 +832,7 @@ public class ORMapService implements RMapService {
 	 * @see info.rmapproject.core.rmapservice.RMapService#createAgent(RMapAgent, java.net.URI)
 	 */
 	@Override
-	public RMapEvent updateAgent(RMapAgent agent, RMapRequestAgent requestAgent) 
+	public RMapEvent updateAgent(RMapAgent agent, RequestEventDetails reqEventDetails) 
 			throws RMapException, RMapDefectiveArgumentException {
 		if (agent==null){
 			throw new RMapDefectiveArgumentException("Null agent");
@@ -840,13 +840,13 @@ public class ORMapService implements RMapService {
 		if (!(agent instanceof ORMapAgent)){
 			throw new RMapDefectiveArgumentException("unrecognized type for agent");
 		}
-		if (requestAgent==null){
-			throw new RMapDefectiveArgumentException("Null system agent");
+		if (reqEventDetails==null){
+			throw new RMapDefectiveArgumentException("Null reqEventDetails");
 		}
 		RMapEvent event = null;
 		try{
 			ORMapAgent orAgent = (ORMapAgent)agent;
-			event = agentmgr.updateAgent(orAgent, requestAgent, triplestore);
+			event = agentmgr.updateAgent(orAgent, reqEventDetails, triplestore);
 		} catch (RMapException ex) {
 			try {
 				//there has been an error during an update so try to rollback the transaction
@@ -865,7 +865,7 @@ public class ORMapService implements RMapService {
 	 * @see info.rmapproject.core.rmapservice.RMapService#createAgent(java.net.URI, String, java.net.URI, java.net.URI, java.net.URI)
 	 */
 	@Override
-	public RMapEvent updateAgent(URI agentID, String name, URI identityProvider, URI authKeyUri, RMapRequestAgent requestAgent) 
+	public RMapEvent updateAgent(URI agentID, String name, URI identityProvider, URI authKeyUri, RequestEventDetails reqEventDetails) 
 			throws RMapException, RMapDefectiveArgumentException {
 		if (agentID==null){
 			throw new RMapDefectiveArgumentException("Null Agent ID");
@@ -879,8 +879,8 @@ public class ORMapService implements RMapService {
 		if (authKeyUri==null){
 			throw new RMapDefectiveArgumentException("Null Agent authorization ID");
 		}
-		if (requestAgent==null){
-			throw new RMapDefectiveArgumentException("Null creating agent");
+		if (reqEventDetails==null){
+			throw new RMapDefectiveArgumentException("Null reqEventDetails");
 		}
 		
 		Value nameValue = ORAdapter.getValueFactory().createLiteral(name);
@@ -888,7 +888,7 @@ public class ORMapService implements RMapService {
 		IRI oIdentityProvider = uri2OpenRdfIri(identityProvider);
 		IRI oAuthKeyUri = uri2OpenRdfIri(authKeyUri);
 		RMapAgent agent = new ORMapAgent(oAgentId, oIdentityProvider, oAuthKeyUri, nameValue);
-		RMapEvent event = updateAgent(agent, requestAgent);
+		RMapEvent event = updateAgent(agent, reqEventDetails);
 		return event;
 	}
 		

--- a/core/src/test/java/info/rmapproject/core/ObjectSerializationTest.java
+++ b/core/src/test/java/info/rmapproject/core/ObjectSerializationTest.java
@@ -28,7 +28,7 @@ import info.rmapproject.core.model.impl.openrdf.ORAdapter;
 import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
 import info.rmapproject.core.model.impl.openrdf.ORMapDiSCO;
 import info.rmapproject.core.model.impl.openrdf.ORMapEventCreation;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import org.junit.Test;
 import org.openrdf.model.IRI;
 import org.openrdf.model.Statement;
@@ -87,13 +87,14 @@ public class ObjectSerializationTest {
     @Test
     public void serializeEventCreation() throws Exception {
         IRI eventIri = TestUtil.asIri("http://example.com/event/" + count());
-        RMapRequestAgent requestAgent = new RMapRequestAgent(create("http://example.org/agent/" + count()),
+        RequestEventDetails reqEventDetails = new RequestEventDetails(create("http://example.org/agent/" + count()),
                 create("http://example.org/agent/key"));
         RMapEventTargetType type = RMapEventTargetType.DISCO;
         RMapLiteral desc = new RMapLiteral("Creation Event Description");
         List<RMapIri> created = singletonList(TestUtil.asRmapIri("http://example.org/disco/" + count()));
+        reqEventDetails.setDescription(desc);
 
-        ORMapEventCreation event = new ORMapEventCreation(eventIri, requestAgent, type, desc, created);
+        ORMapEventCreation event = new ORMapEventCreation(eventIri, reqEventDetails, type, created);
 
         serializeTest(event);
     }

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreationTest.java
@@ -47,7 +47,7 @@ import info.rmapproject.core.CoreTestAbstract;
 import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rmapservice.impl.openrdf.ORMapEventMgr;
 //import info.rmapproject.core.rmapservice.impl.openrdf.ORMapStatementMgr;
 import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
@@ -100,8 +100,8 @@ public class ORMapEventCreationTest extends CoreTestAbstract {
 			for (IRI iri:iris){
 				createdObjIds.add(ORAdapter.openRdfIri2RMapIri(iri));
 			}
-			RMapRequestAgent requestAgent = new RMapRequestAgent(associatedAgent.getIri());
-			ORMapEventCreation event = new ORMapEventCreation(uri2OpenRdfIri(create("http://example.org/event/1")), requestAgent, RMapEventTargetType.DISCO, null, createdObjIds);
+			RequestEventDetails reqEventDetails = new RequestEventDetails(associatedAgent.getIri());
+			ORMapEventCreation event = new ORMapEventCreation(uri2OpenRdfIri(create("http://example.org/event/1")), reqEventDetails, RMapEventTargetType.DISCO, createdObjIds);
 			Date end = new Date();
 			event.setEndTime(end);
 			Model eventModel = event.getAsModel();

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletionTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletionTest.java
@@ -50,7 +50,7 @@ import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.RMapLiteral;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
 import info.rmapproject.core.utils.DateUtils;
 import info.rmapproject.core.vocabulary.impl.openrdf.PROV;
@@ -164,8 +164,9 @@ public class ORMapEventDeletionTest extends CoreTestAbstract {
 			
 			ORMapDiSCO disco = new ORMapDiSCO(uri2OpenRdfIri(create("http://example.org/disco/1")), associatedAgent, resourceList);
 			
-			RMapRequestAgent requestAgent = new RMapRequestAgent(associatedAgent.getIri(), new java.net.URI("ark:/29297/testkey"));
-			ORMapEventDeletion event = new ORMapEventDeletion(uri2OpenRdfIri(create("http://example.org/event/1")), requestAgent, RMapEventTargetType.DISCO, desc);
+			RequestEventDetails reqEventDetails = new RequestEventDetails(associatedAgent.getIri(), new java.net.URI("ark:/29297/testkey"));
+			reqEventDetails.setDescription(desc);
+			ORMapEventDeletion event = new ORMapEventDeletion(uri2OpenRdfIri(create("http://example.org/event/1")), reqEventDetails, RMapEventTargetType.DISCO);
 			RMapIri discoId = ORAdapter.openRdfIri2RMapIri(disco.getDiscoContext());
 			List<RMapIri>deleted = new ArrayList<RMapIri>();
 			deleted.add(discoId);

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivationTest.java
@@ -54,7 +54,7 @@ import info.rmapproject.core.idservice.IdService;
 import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
 import info.rmapproject.core.utils.DateUtils;
 import info.rmapproject.core.vocabulary.impl.openrdf.PROV;
@@ -114,8 +114,8 @@ public class ORMapEventDerivationTest extends CoreTestAbstract {
 		ORMapDiSCO newDisco = new ORMapDiSCO(uri2OpenRdfIri(create("http://example.org/disco/1")), openRdfIri2RMapIri(associatedAgent), resourceList);
 		IRI derivedObject = newDisco.getDiscoContext();
 
-		RMapRequestAgent requestAgent = new RMapRequestAgent(new URI(associatedAgent.stringValue()), new URI("ark:/29297/testkey"));
-		ORMapEventDerivation event = new ORMapEventDerivation(uri2OpenRdfIri(create("http://example.org/event/1")), requestAgent, RMapEventTargetType.DISCO,sourceObject, derivedObject);
+		RequestEventDetails reqEventDetails = new RequestEventDetails(new URI(associatedAgent.stringValue()), new URI("ark:/29297/testkey"));
+		ORMapEventDerivation event = new ORMapEventDerivation(uri2OpenRdfIri(create("http://example.org/event/1")), reqEventDetails, RMapEventTargetType.DISCO, sourceObject, derivedObject);
 		Model model = event.getAsModel();
 		int modelSize = model.size();
 		assertEquals(9,modelSize);

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivationTest.java
@@ -172,8 +172,7 @@ public class ORMapEventInactivationTest extends CoreTestAbstract {
 			fail("could not create agent");
 		}
 		RMapLiteral desc = new RMapLiteral("This is an inactivation event");		
-		RequestEventDetails reqEventDetails = new RequestEventDetails(associatedAgent.getIri(), new URI("ark:/29297/testkey"));
-		reqEventDetails.setDescription(desc);
+		RequestEventDetails reqEventDetails = new RequestEventDetails(associatedAgent.getIri(), new URI("ark:/29297/testkey"), desc);
 		ORMapEventInactivation event = new ORMapEventInactivation(uri2OpenRdfIri(create("http://example.org/event/1")), reqEventDetails, RMapEventTargetType.DISCO);
 		Model model = event.getAsModel();
 		assertEquals(7, model.size());

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivationTest.java
@@ -50,7 +50,7 @@ import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.RMapLiteral;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
 import info.rmapproject.core.utils.DateUtils;
 import info.rmapproject.core.vocabulary.impl.openrdf.PROV;
@@ -172,8 +172,9 @@ public class ORMapEventInactivationTest extends CoreTestAbstract {
 			fail("could not create agent");
 		}
 		RMapLiteral desc = new RMapLiteral("This is an inactivation event");		
-		RMapRequestAgent requestAgent = new RMapRequestAgent(associatedAgent.getIri(), new URI("ark:/29297/testkey"));
-		ORMapEventInactivation event = new ORMapEventInactivation(uri2OpenRdfIri(create("http://example.org/event/1")), requestAgent,RMapEventTargetType.DISCO, desc);
+		RequestEventDetails reqEventDetails = new RequestEventDetails(associatedAgent.getIri(), new URI("ark:/29297/testkey"));
+		reqEventDetails.setDescription(desc);
+		ORMapEventInactivation event = new ORMapEventInactivation(uri2OpenRdfIri(create("http://example.org/event/1")), reqEventDetails, RMapEventTargetType.DISCO);
 		Model model = event.getAsModel();
 		assertEquals(7, model.size());
 		

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapAgentMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapAgentMgrTest.java
@@ -100,7 +100,7 @@ public class ORMapAgentMgrTest extends ORMapMgrTest{
 										TestConstants.SYSAGENT2_NAME, 
 										new java.net.URI(TestConstants.SYSAGENT_ID_PROVIDER), 
 										new java.net.URI(TestConstants.SYSAGENT_AUTH_ID), 
-										requestAgent);
+										reqEventDetails);
 			
 			assertTrue(event.getAssociatedAgent().toString().equals(TestConstants.SYSAGENT_ID));
 			assertTrue(event.getDescription().toString().contains("foaf:name"));
@@ -114,7 +114,7 @@ public class ORMapAgentMgrTest extends ORMapMgrTest{
 										TestConstants.SYSAGENT_NAME, 
 										new java.net.URI(TestConstants.SYSAGENT_ID_PROVIDER), 
 										new java.net.URI(TestConstants.SYSAGENT_AUTH_ID), 
-										requestAgent);
+										reqEventDetails);
 			
 			//now read agent and check it was updated.
 			readagent = rmapService.readAgent(agentId);

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgrTest.java
@@ -75,9 +75,9 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			RMapIri idIRI = disco.getId();
 			String description = disco.getDescription().toString();
 			
-			requestAgent.setAgentKeyId(new java.net.URI("rmap:testkey"));
+			reqEventDetails.setAgentKeyId(new java.net.URI("rmap:testkey"));
 			
-			discomgr.createDiSCO(disco, requestAgent, triplestore);
+			discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			
 			//read DiSCO back
 			IRI dIri = ORAdapter.rMapIri2OpenRdfIri(idIRI);
@@ -102,8 +102,8 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 		try {
 			// now create DiSCO	
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML_NO_AGGREGATES);	
-			requestAgent.setAgentKeyId(new java.net.URI("rmap:testkey"));
-			discomgr.createDiSCO(disco, requestAgent, triplestore);									
+			reqEventDetails.setAgentKeyId(new java.net.URI("rmap:testkey"));
+			discomgr.createDiSCO(disco, reqEventDetails, triplestore);									
 		} catch (Exception e) {
 			e.printStackTrace();
 			assertTrue(e.getMessage().contains("No aggregated resource statements"));
@@ -123,8 +123,8 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			RMapIri idIRI = disco.getId();
 			String description = disco.getDescription().toString();
 			
-			requestAgent.setAgentKeyId(new java.net.URI("rmap:testkey"));
-			discomgr.createDiSCO(disco, requestAgent, triplestore);
+			reqEventDetails.setAgentKeyId(new java.net.URI("rmap:testkey"));
+			discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			
 			//read DiSCO back
 			IRI dIri = ORAdapter.rMapIri2OpenRdfIri(idIRI);
@@ -154,9 +154,9 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			// now create DiSCO	
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML_NO_BODY_NO_AGGREGATES);	
 			
-			requestAgent.setAgentKeyId(new java.net.URI("rmap:testkey"));
+			reqEventDetails.setAgentKeyId(new java.net.URI("rmap:testkey"));
 			
-			discomgr.createDiSCO(disco, requestAgent, triplestore);
+			discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 				
 			
 		} catch (Exception e) {
@@ -179,9 +179,9 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			// now create DiSCO	
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML_AGGREGATES_ONLY);	
 			
-			requestAgent.setAgentKeyId(new java.net.URI("rmap:testkey"));
+			reqEventDetails.setAgentKeyId(new java.net.URI("rmap:testkey"));
 			
-			discomgr.createDiSCO(disco, requestAgent, triplestore);
+			discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 				
 			
 		} catch (Exception e) {
@@ -206,7 +206,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML);
 			RMapIri idIRI = disco.getId();
 			
-			RMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			RMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			assertTrue(event!=null);
 			
 			//read DiSCO back
@@ -219,11 +219,11 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			boolean correctErrorThrown = false;
 			// now update DiSCO	
 			ORMapDiSCO disco2 = getRMapDiSCO(TestFile.DISCOA_XML);
-			discomgr.updateDiSCO(dIri, disco2, requestAgent, false, triplestore);
+			discomgr.updateDiSCO(dIri, disco2, reqEventDetails, false, triplestore);
 			
 			ORMapDiSCO disco3 = getRMapDiSCO(TestFile.DISCOA_XML);
 			try{
-				discomgr.updateDiSCO(dIri, disco3, requestAgent, false, triplestore);
+				discomgr.updateDiSCO(dIri, disco3, reqEventDetails, false, triplestore);
 			} catch(RMapNotLatestVersionException ex){
 				if (ex.getMessage().contains("latest version")){
 					correctErrorThrown=true;
@@ -235,7 +235,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			//now update with different agent using latest id
 			try{
 				IRI dIri2 = ORAdapter.rMapIri2OpenRdfIri(disco2.getId());
-				discomgr.updateDiSCO(dIri2, disco3, requestAgent2, false, triplestore);
+				discomgr.updateDiSCO(dIri2, disco3, reqEventDetails2, false, triplestore);
 			} catch(Exception ex){
 				ex.printStackTrace();
 			}
@@ -271,7 +271,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			RMapIri idIRI = disco.getId();
 			String description = disco.getDescription().toString();
 			
-			RMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			RMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 						
 			IRI dIri = ORAdapter.rMapIri2OpenRdfIri(idIRI);
 			ORMapDiSCO rDisco = discomgr.readDiSCO(dIri, triplestore);
@@ -281,7 +281,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			assertEquals(description,description2);
 			RMapTriple triple = rDisco.getRelatedStatements().get(19);
 			assertTrue(triple.getSubject() instanceof RMapIri);
-			rmapService.deleteDiSCO(disco.getId().getIri(), requestAgent);
+			rmapService.deleteDiSCO(disco.getId().getIri(), reqEventDetails);
 			assertEquals(event.getAssociatedAgent().toString(),TestConstants.SYSAGENT_ID);
 			
 		} catch (Exception ex) {
@@ -297,7 +297,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 	public void testCreateDiSCOWithUserKeyIdAssociated() {
 		try {			
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_TURTLE);
-			RMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			RMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			assertTrue(event.getAssociatedKey().toString().equals(TestConstants.SYSAGENT_KEY)); 		
 		} catch (Exception ex) {
 			ex.printStackTrace();
@@ -313,7 +313,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 	public void testCreateDiSCOWithProviderId() throws Exception {
 		String providerId = "ark:/00000/providerid";
 		ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML_WITH_PROVIDERID);
-		RMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+		RMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 		assertTrue(event!=null);
 		assertEquals(disco.getProviderId(),providerId); 		
 		assertFalse(disco.getId().equals(providerId));
@@ -331,7 +331,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			RMapIri idIRI = disco.getId();
 			
 			@SuppressWarnings("unused")
-			RMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			RMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			
 			//read DiSCO back
 			IRI dIri = ORAdapter.rMapIri2OpenRdfIri(idIRI);
@@ -341,21 +341,21 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			
 			// now update DiSCO	
 			ORMapDiSCO disco2 = getRMapDiSCO(TestFile.DISCOA_XML);
-			discomgr.updateDiSCO(dIri, disco2, requestAgent, false, triplestore);
+			discomgr.updateDiSCO(dIri, disco2, reqEventDetails, false, triplestore);
 			IRI dIri2 = ORAdapter.rMapIri2OpenRdfIri(disco2.getId());
 			
 			//update again
 			ORMapDiSCO disco3 = getRMapDiSCO(TestFile.DISCOA_XML);
-			discomgr.updateDiSCO(dIri2, disco3, requestAgent, false, triplestore);
+			discomgr.updateDiSCO(dIri2, disco3, reqEventDetails, false, triplestore);
 			
 
 			IRI dIri3 = ORAdapter.rMapIri2OpenRdfIri(disco3.getId());
 			//update with different agent using latest id
 			ORMapDiSCO disco4 = getRMapDiSCO(TestFile.DISCOA_XML);
-			discomgr.updateDiSCO(dIri3, disco4, requestAgent2, false, triplestore);
+			discomgr.updateDiSCO(dIri3, disco4, reqEventDetails2, false, triplestore);
 
 			
-			rmapService.deleteDiSCO(disco.getId().getIri(), requestAgent);
+			rmapService.deleteDiSCO(disco.getId().getIri(), reqEventDetails);
 			
 			NavigableMap<Date, java.net.URI> versions = new TreeMap<Date, java.net.URI>();
 			versions.putAll(rmapService.getDiSCOAgentVersionsWithDates(new java.net.URI(dIri3.toString())));
@@ -405,7 +405,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 		try {
 			// now create DiSCO	
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML);
-			discomgr.createDiSCO(disco, requestAgent, triplestore);
+			discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			URI dUri = disco.getId().getIri();
 			IRI dIri = ORAdapter.uri2OpenRdfIri(dUri);
 			
@@ -415,13 +415,13 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			
 			// now update DiSCO	
 			ORMapDiSCO disco2 = getRMapDiSCO(TestFile.DISCOA_XML);
-			discomgr.updateDiSCO(dIri, disco2, requestAgent, false, triplestore);
+			discomgr.updateDiSCO(dIri, disco2, reqEventDetails, false, triplestore);
 			URI dUri2 = disco2.getId().getIri();
 			IRI dIri2 = ORAdapter.uri2OpenRdfIri(dUri2);
 			
 			//update again with different agent to do derivation
 			ORMapDiSCO disco3 = getRMapDiSCO(TestFile.DISCOA_XML);
-			discomgr.updateDiSCO(dIri2, disco3, requestAgent2, false, triplestore);
+			discomgr.updateDiSCO(dIri2, disco3, reqEventDetails2, false, triplestore);
 			URI dUri3 = disco3.getId().getIri();
 			
 			List<URI> versionsForSource = rmapService.getDiSCOAllVersions(dUri2);

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapEventMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapEventMgrTest.java
@@ -116,7 +116,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testCreateAndReadbackCreationEventWithAgentApiKey() {
 		try {
-			ORMapEventCreation event = new ORMapEventCreation(fakeIri1, requestAgent,RMapEventTargetType.DISCO);
+			ORMapEventCreation event = new ORMapEventCreation(fakeIri1, reqEventDetails,RMapEventTargetType.DISCO);
 			event.setEndTime(new Date());
 			event.setCreatedObjectIdsFromIRI(iriSet1);
 			
@@ -147,7 +147,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testCreateAndReadbackCreationEventNoAgentApiKey() {
 		try {
-			ORMapEventCreation event = new ORMapEventCreation(fakeIri1, requestAgent2,RMapEventTargetType.DISCO);
+			ORMapEventCreation event = new ORMapEventCreation(fakeIri1, reqEventDetails2,RMapEventTargetType.DISCO);
 			event.setEndTime(new Date());
 			event.setCreatedObjectIdsFromIRI(iriSet1);
 			IRI eventIri = eventmgr.createEvent(event, triplestore);
@@ -169,7 +169,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testCreateAndReadbackTombstoneEvent() {
 		try {
-			ORMapEventTombstone event = new ORMapEventTombstone(fakeIri1, requestAgent,RMapEventTargetType.DISCO, fakeIri1);
+			ORMapEventTombstone event = new ORMapEventTombstone(fakeIri1, reqEventDetails,RMapEventTargetType.DISCO, fakeIri1);
 			event.setEndTime(new Date());
 			IRI eventIri = eventmgr.createEvent(event, triplestore);
 
@@ -198,7 +198,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testCreateAndReadbackDeletionEvent() {
 		try {
-			ORMapEventDeletion event = new ORMapEventDeletion(fakeIri1, requestAgent,RMapEventTargetType.DISCO, ORAdapter.openRdfIri2RMapIri(fakeIri1));
+			ORMapEventDeletion event = new ORMapEventDeletion(fakeIri1, reqEventDetails, RMapEventTargetType.DISCO);
 			List <RMapIri> delIris = new ArrayList<RMapIri>();
 			delIris.add(ORAdapter.openRdfIri2RMapIri(fakeIri1));
 			event.setDeletedObjectIds(delIris);
@@ -230,7 +230,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testCreateAndReadbackDerivationEvent() {
 		try {
-			ORMapEventDerivation event = new ORMapEventDerivation(fakeIri1, requestAgent, RMapEventTargetType.DISCO, fakeIri1, fakeIri2);
+			ORMapEventDerivation event = new ORMapEventDerivation(fakeIri1, reqEventDetails, RMapEventTargetType.DISCO, fakeIri1, fakeIri2);
 			event.setEndTime(new Date());
 			IRI eventIri = eventmgr.createEvent(event, triplestore);
 
@@ -260,7 +260,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testCreateAndReadbackInactivationEvent() {
 		try {
-			ORMapEventInactivation event = new ORMapEventInactivation(fakeIri1, requestAgent, RMapEventTargetType.DISCO);
+			ORMapEventInactivation event = new ORMapEventInactivation(fakeIri1, reqEventDetails, RMapEventTargetType.DISCO);
 			event.setEndTime(new Date());
 			event.setInactivatedObjectId(ORAdapter.openRdfIri2RMapIri(fakeIri1));
 			IRI eventIri = eventmgr.createEvent(event, triplestore);
@@ -289,7 +289,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testCreateAndReadbackReplaceEvent() {
 		try {
-			ORMapEventUpdateWithReplace event = new ORMapEventUpdateWithReplace(fakeIri1, requestAgent, RMapEventTargetType.AGENT, agentIri);
+			ORMapEventUpdateWithReplace event = new ORMapEventUpdateWithReplace(fakeIri1, reqEventDetails, RMapEventTargetType.AGENT, agentIri);
 			event.setEndTime(new Date());
 			IRI eventIri = eventmgr.createEvent(event, triplestore);
 
@@ -318,7 +318,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testCreateAndReadbackUpdateEvent() {
 		try {
-			ORMapEventUpdate event = new ORMapEventUpdate(fakeIri1, requestAgent, RMapEventTargetType.DISCO, fakeIri1, fakeIri2);
+			ORMapEventUpdate event = new ORMapEventUpdate(fakeIri1, reqEventDetails, RMapEventTargetType.DISCO, fakeIri1, fakeIri2);
 			event.setEndTime(new Date());
 			IRI eventIri = eventmgr.createEvent(event, triplestore);
 			
@@ -348,7 +348,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testGetEventStartAndEndDate() {
 		try {
-			ORMapEventCreation event = new ORMapEventCreation(fakeIri1, requestAgent,RMapEventTargetType.DISCO);
+			ORMapEventCreation event = new ORMapEventCreation(fakeIri1, reqEventDetails,RMapEventTargetType.DISCO);
 			event.setCreatedObjectIdsFromIRI(iriSet1);
 			event.setEndTime(new Date());
 			IRI eventIri = eventmgr.createEvent(event, triplestore);
@@ -376,7 +376,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 	@Test
 	public void testGetEventAffectedAgents() {
 		try {
-			ORMapEventCreation createEvent = new ORMapEventCreation(fakeIri1, requestAgent,RMapEventTargetType.AGENT);
+			ORMapEventCreation createEvent = new ORMapEventCreation(fakeIri1, reqEventDetails,RMapEventTargetType.AGENT);
 			createEvent.setEndTime(new Date());
 			createEvent.setCreatedObjectIdsFromIRI(agentIriSet);
 			IRI eventIri = eventmgr.createEvent(createEvent, triplestore);
@@ -384,7 +384,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 			assertEquals(createEventAgents.size(),1);	
 			assertEquals(createEventAgents.get(0).toString(),createEvent.getCreatedObjectIds().get(0).toString());			
 			
-			ORMapEventUpdateWithReplace replaceEvent = new ORMapEventUpdateWithReplace(fakeIri1, requestAgent, RMapEventTargetType.AGENT, agentIri);
+			ORMapEventUpdateWithReplace replaceEvent = new ORMapEventUpdateWithReplace(fakeIri1, reqEventDetails, RMapEventTargetType.AGENT, agentIri);
 			replaceEvent.setEndTime(new Date());
 			eventIri = eventmgr.createEvent(replaceEvent, triplestore);
 			List<IRI> replaceEventAgents = eventmgr.getAffectedAgents(eventIri, triplestore);
@@ -406,7 +406,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 		try {			
 			// now create DiSCO	
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOB_V1_XML);
-			ORMapEventCreation event = (ORMapEventCreation) discomgr.createDiSCO(disco, requestAgent, triplestore);
+			ORMapEventCreation event = (ORMapEventCreation) discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 
 			IRI discoIri = ORAdapter.rMapIri2OpenRdfIri(disco.getId());
 			IRI eventIri = ORAdapter.rMapIri2OpenRdfIri(event.getId());
@@ -417,7 +417,7 @@ public class ORMapEventMgrTest extends ORMapMgrTest{
 			affectedDiscos.clear();
 			
 			ORMapDiSCO disco2 = getRMapDiSCO(TestFile.DISCOB_V2_XML);
-			RMapEvent updateEvent = discomgr.updateDiSCO(discoIri, disco2, requestAgent, false, triplestore);
+			RMapEvent updateEvent = discomgr.updateDiSCO(discoIri, disco2, reqEventDetails, false, triplestore);
 			
 			IRI disco2Iri = ORAdapter.rMapIri2OpenRdfIri(disco2.getId());
 			IRI event2Iri = ORAdapter.rMapIri2OpenRdfIri(updateEvent.getId());

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapMgrTest.java
@@ -43,7 +43,7 @@ import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.model.impl.openrdf.ORAdapter;
 import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
 import info.rmapproject.core.model.impl.openrdf.ORMapDiSCO;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rdfhandler.RDFType;
 import info.rmapproject.core.rdfhandler.impl.openrdf.RioRDFHandler;
 import info.rmapproject.core.rmapservice.RMapService;
@@ -73,11 +73,11 @@ public abstract class ORMapMgrTest extends CoreTestAbstract {
 	/** Second general use sysagent for testing that requires 2 users **/
 	protected ORMapAgent sysagent2 = null;
 	
-	/** Request agent based on sysagent. Include key */
-	protected RMapRequestAgent requestAgent = null;
-	
-	/** Request agent based on sysagent2. No Key */
-	protected RMapRequestAgent requestAgent2 = null;
+	/** Create default RequestEventDetails based on sysagent. Include key */
+	protected RequestEventDetails reqEventDetails = null;
+
+	/** Create default RequestEventDetails based on sysagent2. No key */
+	protected RequestEventDetails reqEventDetails2 = null;
 
 
 
@@ -116,14 +116,14 @@ public abstract class ORMapMgrTest extends CoreTestAbstract {
 			Literal NAME = ORAdapter.getValueFactory().createLiteral(TestConstants.SYSAGENT_NAME);	
 			sysagent = new ORMapAgent(AGENT_IRI, ID_PROVIDER_IRI, AUTH_ID_IRI, NAME);
 			
-			if (requestAgent==null){
-				requestAgent = new RMapRequestAgent(new URI(TestConstants.SYSAGENT_ID),new URI(TestConstants.SYSAGENT_KEY));
+			if (reqEventDetails==null){
+				reqEventDetails = new RequestEventDetails(new URI(TestConstants.SYSAGENT_ID),new URI(TestConstants.SYSAGENT_KEY));
 			}
 			
 			//create new test agent
 			URI agentId=sysagent.getId().getIri();
 			if (!rmapService.isAgentId(agentId)) {
-				rmapService.createAgent(sysagent,requestAgent);
+				rmapService.createAgent(sysagent,reqEventDetails);
 			}
 
 			// Check the agent was created
@@ -147,13 +147,13 @@ public abstract class ORMapMgrTest extends CoreTestAbstract {
 			Literal NAME = ORAdapter.getValueFactory().createLiteral(TestConstants.SYSAGENT2_NAME);	
 			sysagent2 = new ORMapAgent(AGENT_IRI, ID_PROVIDER_IRI, AUTH_ID_IRI, NAME);
 			
-			if (requestAgent2==null){
-				requestAgent2 = new RMapRequestAgent(new URI(TestConstants.SYSAGENT2_ID));
+			if (reqEventDetails2==null){
+				reqEventDetails2 = new RequestEventDetails(new URI(TestConstants.SYSAGENT2_ID));
 			}
 			
 			URI agentId=sysagent2.getId().getIri();
 			if (!rmapService.isAgentId(agentId)) {
-				rmapService.createAgent(sysagent2,requestAgent);
+				rmapService.createAgent(sysagent2,reqEventDetails);
 			}
 
 			// Check the agent was created

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapObjectMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapObjectMgrTest.java
@@ -105,12 +105,12 @@ public class ORMapObjectMgrTest extends ORMapMgrTest {
 	public void testIsRMapType() {
 		try {
 			//check agent type
-			boolean istype = discomgr.isRMapType(triplestore, ORAdapter.uri2OpenRdfIri(requestAgent.getSystemAgent()), RMAP.AGENT);
+			boolean istype = discomgr.isRMapType(triplestore, ORAdapter.uri2OpenRdfIri(reqEventDetails.getSystemAgent()), RMAP.AGENT);
 			assertTrue(istype);
 			
 			//check disco type
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML);
-			ORMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			ORMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			URI dUri = disco.getId().getIri();
 			IRI dIri = ORAdapter.uri2OpenRdfIri(dUri);			
 			istype = discomgr.isRMapType(triplestore, dIri, RMAP.DISCO);
@@ -155,7 +155,7 @@ public class ORMapObjectMgrTest extends ORMapMgrTest {
 				createdObjIds.add(ORAdapter.openRdfIri2RMapIri(iri));
 			}
 			
-			ORMapEventCreation event = new ORMapEventCreation(ORAdapter.uri2OpenRdfIri(rmapIdService.createId()), requestAgent, RMapEventTargetType.DISCO, null, createdObjIds);
+			ORMapEventCreation event = new ORMapEventCreation(ORAdapter.uri2OpenRdfIri(rmapIdService.createId()), reqEventDetails, RMapEventTargetType.DISCO, createdObjIds);
 			Date end = new Date();
 			event.setEndTime(end);
 			ORMapEventMgr eventMgr = new ORMapEventMgr();

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapResourceMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapResourceMgrTest.java
@@ -94,7 +94,7 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 		try {		
 			//create disco				
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML);
-			ORMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			ORMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 		
 			//get related discos
 			IRI iri = ORAdapter.getValueFactory().createIRI(TestConstants.TEST_DISCO_DOI);
@@ -120,7 +120,7 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 
 			params.setStatusCode(RMapStatusFilter.ACTIVE);
 			
-			discomgr.updateDiSCO(matchingIri, null, requestAgent, true, triplestore);
+			discomgr.updateDiSCO(matchingIri, null, reqEventDetails, true, triplestore);
 			discoIris = resourcemgr.getResourceRelatedDiSCOS(iri, params, triplestore);
 			assertTrue(discoIris.size()==0);
 
@@ -141,11 +141,11 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 		try {
 			//create disco				
 			ORMapDiSCO disco1 = getRMapDiSCO(TestFile.DISCOA_XML);		
-			ORMapEvent event1 = discomgr.createDiSCO(disco1, requestAgent, triplestore);
+			ORMapEvent event1 = discomgr.createDiSCO(disco1, reqEventDetails, triplestore);
 
 			//create duplicate disco, same agent - we want to make sure agents only come through once.				
 			ORMapDiSCO disco2 = getRMapDiSCO(TestFile.DISCOA_XML);		
-			ORMapEvent event2 = discomgr.createDiSCO(disco2, requestAgent, triplestore);
+			ORMapEvent event2 = discomgr.createDiSCO(disco2, reqEventDetails, triplestore);
 		
 			Set <URI> sysAgents = new HashSet<URI>();
 			sysAgents.add(new URI(TestConstants.SYSAGENT_ID));
@@ -181,12 +181,12 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 			//create disco			
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML);			
 			ORMapDiSCO disco2 = getRMapDiSCO(TestFile.DISCOA_XML);	
-			ORMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			ORMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			
 			//get related events
 			RMapIri eventId = event.getId();
 			IRI discoId = ORAdapter.rMapIri2OpenRdfIri(disco.getId());
-			RMapEvent updateEvent = discomgr.updateDiSCO(discoId, disco2, requestAgent, false, triplestore);
+			RMapEvent updateEvent = discomgr.updateDiSCO(discoId, disco2, reqEventDetails, false, triplestore);
 			IRI updateEventId = ORAdapter.rMapIri2OpenRdfIri(updateEvent.getId());
 			
 			IRI iri = ORAdapter.getValueFactory().createIRI(TestConstants.TEST_DISCO_DOI);
@@ -227,11 +227,11 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 			
 			//create disco				
 			ORMapDiSCO disco1 = getRMapDiSCO(TestFile.DISCOA_XML);		
-			ORMapEvent event1 = discomgr.createDiSCO(disco1, requestAgent, triplestore);
+			ORMapEvent event1 = discomgr.createDiSCO(disco1, reqEventDetails, triplestore);
 
 			//create duplicate disco - we want to make sure triples only come through once.				
 			ORMapDiSCO disco2 = getRMapDiSCO(TestFile.DISCOA_XML);		
-			ORMapEvent event2 = discomgr.createDiSCO(disco2, requestAgent, triplestore);
+			ORMapEvent event2 = discomgr.createDiSCO(disco2, reqEventDetails, triplestore);
 			
 			//get related triples			
 			IRI iri = ORAdapter.getValueFactory().createIRI(TestConstants.TEST_DISCO_DOI);
@@ -310,11 +310,11 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 
 			//create disco				
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML);	
-			ORMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			ORMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 
 			ORMapDiSCO disco2 = getRMapDiSCO(TestFile.DISCOA_XML);
-			requestAgent.setAgentKeyId(new java.net.URI(TestConstants.SYSAGENT_KEY));
-			ORMapEvent event2 = discomgr.createDiSCO(disco2, requestAgent, triplestore);
+			reqEventDetails.setAgentKeyId(new java.net.URI(TestConstants.SYSAGENT_KEY));
+			ORMapEvent event2 = discomgr.createDiSCO(disco2, reqEventDetails, triplestore);
 		
 			RMapSearchParams params = paramsFactory.newInstance();
 			params.setStatusCode(RMapStatusFilter.ACTIVE);

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapStatementMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapStatementMgrTest.java
@@ -71,7 +71,7 @@ public class ORMapStatementMgrTest extends ORMapMgrTest {
 
 			//create disco		
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML);
-			discomgr.createDiSCO(disco, requestAgent, triplestore);
+			discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			RMapIri discoId = disco.getId();
 			
 			//get related discos
@@ -96,7 +96,7 @@ public class ORMapStatementMgrTest extends ORMapMgrTest {
 			assertTrue(matchingDiscoId.toString().equals(discoId.toString()));
 			
 			
-			discomgr.updateDiSCO(matchingDiscoId, null, requestAgent, true, triplestore);
+			discomgr.updateDiSCO(matchingDiscoId, null, reqEventDetails, true, triplestore);
 			discoIds = stmtmgr.getRelatedDiSCOs(subject, predicate, object, params, triplestore);
 			assertTrue(discoIds.size()==0);
 			
@@ -117,7 +117,7 @@ public class ORMapStatementMgrTest extends ORMapMgrTest {
 		try {
 			//create disco				
 			ORMapDiSCO disco = getRMapDiSCO(TestFile.DISCOA_XML);
-			ORMapEvent event = discomgr.createDiSCO(disco, requestAgent, triplestore);
+			ORMapEvent event = discomgr.createDiSCO(disco, reqEventDetails, triplestore);
 			
 			Set <URI> sysAgents = new HashSet<URI>();
 			sysAgents.add(new URI(TestConstants.SYSAGENT_ID));

--- a/integration/src/test/java/info/rmapproject/integration/ManagerObjectSerializationIT.java
+++ b/integration/src/test/java/info/rmapproject/integration/ManagerObjectSerializationIT.java
@@ -29,7 +29,7 @@ import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
 import info.rmapproject.core.model.impl.openrdf.ORMapDiSCO;
 import info.rmapproject.core.model.impl.openrdf.ORMapEvent;
 import info.rmapproject.core.model.impl.openrdf.ORMapEventCreation;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rmapservice.RMapService;
 import info.rmapproject.core.rmapservice.impl.openrdf.ORMapAgentMgr;
 import info.rmapproject.core.rmapservice.impl.openrdf.ORMapDiSCOMgr;
@@ -109,7 +109,7 @@ public class ManagerObjectSerializationIT {
                                         asIri(SYSAGENT_AUTH_ID),
                                         asLiteral(SYSAGENT_NAME));
 
-    private RMapRequestAgent requestAgent = new RMapRequestAgent(create(SYSAGENT_ID), create(SYSAGENT_KEY));
+    private RequestEventDetails reqEventDetails = new RequestEventDetails(create(SYSAGENT_ID), create(SYSAGENT_KEY));
 
     @Before
     public void setUp() throws Exception {
@@ -119,9 +119,9 @@ public class ManagerObjectSerializationIT {
             // don't care
         }
 
-        rMapService.createAgent(systemAgent, requestAgent);
+        rMapService.createAgent(systemAgent, reqEventDetails);
 
-        serializeTest(requestAgent);
+        serializeTest(reqEventDetails);
         serializeTest(systemAgent);
     }
 
@@ -135,7 +135,7 @@ public class ManagerObjectSerializationIT {
         ORMapDiSCO disco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
         serializeTest(disco);
 
-        RMapEvent event = discoMgr.createDiSCO(disco, requestAgent, triplestore);
+        RMapEvent event = discoMgr.createDiSCO(disco, reqEventDetails, triplestore);
 
         assertNotNull(event);
         serializeTest(event);
@@ -144,9 +144,9 @@ public class ManagerObjectSerializationIT {
     @Test
     public void discoManagerTombstoneSerialization() throws Exception {
         ORMapDiSCO disco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
-        discoMgr.createDiSCO(disco, requestAgent, triplestore);
+        discoMgr.createDiSCO(disco, reqEventDetails, triplestore);
 
-        RMapEvent event = discoMgr.tombstoneDiSCO(DISCO_IRI, requestAgent, triplestore);
+        RMapEvent event = discoMgr.tombstoneDiSCO(DISCO_IRI, reqEventDetails, triplestore);
 
         assertNotNull(event);
         serializeTest(event);
@@ -155,7 +155,7 @@ public class ManagerObjectSerializationIT {
     @Test
     public void discoManagerUpdateSerialization() throws Exception {
         ORMapDiSCO originalDisco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
-        discoMgr.createDiSCO(originalDisco, requestAgent, triplestore);
+        discoMgr.createDiSCO(originalDisco, reqEventDetails, triplestore);
 
         ORMapDiSCO newDisco = new ORMapDiSCO(
                 asIri("http://example.org/disco/2"), CREATOR_IRI, AGGREGATED_RESOURCES);
@@ -166,7 +166,7 @@ public class ManagerObjectSerializationIT {
     @Test
     public void discoManagerInactivateSerialization() throws Exception {
         ORMapDiSCO originalDisco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
-        discoMgr.createDiSCO(originalDisco, requestAgent, triplestore);
+        discoMgr.createDiSCO(originalDisco, reqEventDetails, triplestore);
 
         ORMapDiSCO newDisco = new ORMapDiSCO(
                 asIri("http://example.org/disco/2"), CREATOR_IRI, AGGREGATED_RESOURCES);
@@ -180,8 +180,9 @@ public class ManagerObjectSerializationIT {
         RMapEventTargetType type = RMapEventTargetType.DISCO;
         RMapLiteral desc = new RMapLiteral("Creation Event Description");
         List<RMapIri> created = singletonList(asRmapIri("http://example.org/disco/1"));
-
-        ORMapEventCreation event = new ORMapEventCreation(eventIri, requestAgent, type, desc, created);
+        reqEventDetails.setDescription(desc);
+        
+        ORMapEventCreation event = new ORMapEventCreation(eventIri, reqEventDetails, type, created);
         Calendar endTime = Calendar.getInstance();
         endTime.add(Calendar.MILLISECOND, 500);
         event.setEndTime(endTime.getTime());
@@ -203,7 +204,7 @@ public class ManagerObjectSerializationIT {
         ORMapAgent agent = new ORMapAgent(agentIri, providerIri, authIri, agentName);
         serializeTest(agent);
 
-        ORMapEvent event = agentMgr.createAgent(agent, requestAgent, triplestore);
+        ORMapEvent event = agentMgr.createAgent(agent, reqEventDetails, triplestore);
         assertNotNull(event);
         serializeTest(event);
     }
@@ -211,7 +212,7 @@ public class ManagerObjectSerializationIT {
     @Test
     public void rmapServiceCreateDisco() throws Exception {
         ORMapDiSCO disco = new ORMapDiSCO(DISCO_IRI, CREATOR_IRI, AGGREGATED_RESOURCES);
-        RMapEvent event = rMapService.createDiSCO(disco, requestAgent);
+        RMapEvent event = rMapService.createDiSCO(disco, reqEventDetails);
 
         assertNotNull(event);
         serializeTest(event);
@@ -229,7 +230,7 @@ public class ManagerObjectSerializationIT {
     @Test
     public void rmapServiceCreateAgentTwo() throws Exception {
         RMapEvent event = rMapService.createAgent(create("http://example.org/agent/id"), "Agent Name",
-                create("http://example.org/idp"), create("http://example.org/key"), requestAgent);
+                create("http://example.org/idp"), create("http://example.org/key"), reqEventDetails);
 
         assertNotNull(event);
         serializeTest(event);
@@ -244,7 +245,7 @@ public class ManagerObjectSerializationIT {
         Value agentName = ORAdapter.getValueFactory().createLiteral("An Agent");
         ORMapAgent agent = new ORMapAgent(agentIri, providerIri, authIri, agentName);
 
-        RMapEvent event = rMapService.createAgent(agent, requestAgent);
+        RMapEvent event = rMapService.createAgent(agent, reqEventDetails);
 
         assertNotNull(event);
         serializeTest(event);
@@ -252,7 +253,7 @@ public class ManagerObjectSerializationIT {
 
     private void doUpdateAndPerformAssertions(IRI discoIri, ORMapDiSCO newDisco, boolean inactivate)
             throws IOException, ClassNotFoundException {
-        RMapEvent event = discoMgr.updateDiSCO(discoIri, newDisco, requestAgent, inactivate, triplestore);
+        RMapEvent event = discoMgr.updateDiSCO(discoIri, newDisco, reqEventDetails, inactivate, triplestore);
 
         assertNotNull(event);
         serializeTest(event);

--- a/webapp/src/test/java/info/rmapproject/webapp/WebDataRetrievalTestAbstract.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/WebDataRetrievalTestAbstract.java
@@ -43,7 +43,7 @@ import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.model.impl.openrdf.ORAdapter;
 import info.rmapproject.core.model.impl.openrdf.ORMapAgent;
 import info.rmapproject.core.model.impl.openrdf.ORMapDiSCO;
-import info.rmapproject.core.model.request.RMapRequestAgent;
+import info.rmapproject.core.model.request.RequestEventDetails;
 import info.rmapproject.core.rdfhandler.RDFHandler;
 import info.rmapproject.core.rdfhandler.RDFType;
 import info.rmapproject.core.rdfhandler.impl.openrdf.RioRDFHandler;
@@ -89,7 +89,7 @@ public abstract class WebDataRetrievalTestAbstract extends WebTestAbstract {
 	protected ORMapAgent sysagent = null;
 	
 	/** Request agent based on sysagent. Include key */
-	protected RMapRequestAgent requestAgent = null;
+	protected RequestEventDetails reqEventDetails = null;
 		
 	@Before
 	public void setUp() throws Exception {
@@ -125,14 +125,14 @@ public abstract class WebDataRetrievalTestAbstract extends WebTestAbstract {
 			Literal NAME = ORAdapter.getValueFactory().createLiteral(TestConstants.SYSAGENT_NAME);	
 			sysagent = new ORMapAgent(AGENT_IRI, ID_PROVIDER_IRI, AUTH_ID_IRI, NAME);
 			
-			if (requestAgent==null){
-				requestAgent = new RMapRequestAgent(new URI(TestConstants.SYSAGENT_ID),new URI(TestConstants.SYSAGENT_KEY));
+			if (reqEventDetails==null){
+				reqEventDetails = new RequestEventDetails(new URI(TestConstants.SYSAGENT_ID),new URI(TestConstants.SYSAGENT_KEY));
 			}
 			
 			//create new test agent
 			URI agentId=sysagent.getId().getIri();
 			if (!rmapService.isAgentId(agentId)) {
-				rmapService.createAgent(sysagent,requestAgent);
+				rmapService.createAgent(sysagent,reqEventDetails);
 			}
 
 			// Check the agent was created

--- a/webapp/src/test/java/info/rmapproject/webapp/controllers/ResourceDisplayControllerTest.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/controllers/ResourceDisplayControllerTest.java
@@ -62,7 +62,7 @@ public class ResourceDisplayControllerTest extends WebDataRetrievalTestAbstract 
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOB_V1_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
-		rmapService.createDiSCO(disco, requestAgent);
+		rmapService.createDiSCO(disco, reqEventDetails);
 	
         mockMvc.perform(get("/resources/fakefake%3Auri"))
         	.andExpect(view().name("objectnotfound")); 
@@ -81,7 +81,7 @@ public class ResourceDisplayControllerTest extends WebDataRetrievalTestAbstract 
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOB_V1_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
-		rmapService.createDiSCO(disco, requestAgent);
+		rmapService.createDiSCO(disco, reqEventDetails);
         mockMvc.perform(get("/resources/ark%3A%2F27927%2F12121212"))
         	.andExpect(view().name("resources"));     
         

--- a/webapp/src/test/java/info/rmapproject/webapp/controllers/SearchControllerTest.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/controllers/SearchControllerTest.java
@@ -62,7 +62,7 @@ public class SearchControllerTest extends WebDataRetrievalTestAbstract {
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOB_V1_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
-		rmapService.createDiSCO(disco, requestAgent);
+		rmapService.createDiSCO(disco, reqEventDetails);
     	    	
 		mockMvc.perform(post("/search").param("search", "fakefake:uri"))
 	                .andExpect(view().name("redirect:/resources/fakefake%3Auri"));       
@@ -81,7 +81,7 @@ public class SearchControllerTest extends WebDataRetrievalTestAbstract {
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOB_V1_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
-		rmapService.createDiSCO(disco, requestAgent);
+		rmapService.createDiSCO(disco, reqEventDetails);
 
 		mockMvc.perform(post("/search").param("search", "ark:/27927/12121212"))
 	                .andExpect(view().name("redirect:/resources/ark%3A%2F27927%2F12121212"));       

--- a/webapp/src/test/java/info/rmapproject/webapp/service/DataDisplayServiceImplTest.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/service/DataDisplayServiceImplTest.java
@@ -63,7 +63,7 @@ public class DataDisplayServiceImplTest extends WebDataRetrievalTestAbstract {
 	public void testGetAgentDTO() throws Exception{
 		
 		//get the Agent
-		AgentDTO agentDTO = dataDisplayService.getAgentDTO(requestAgent.getSystemAgent().toString());
+		AgentDTO agentDTO = dataDisplayService.getAgentDTO(reqEventDetails.getSystemAgent().toString());
 		
 		assertEquals(agentDTO.getAuthId(), this.sysagent.getAuthId().toString());
 		assertEquals(agentDTO.getEvents().size(),1);
@@ -86,9 +86,9 @@ public class DataDisplayServiceImplTest extends WebDataRetrievalTestAbstract {
 		ORMapDiSCO disco1 = getRMapDiSCOObj(TestFile.DISCOA_XML);
 		String discoUri1 = disco1.getId().toString();
         assertNotNull(discoUri1);
-		rmapService.createDiSCO(disco1, requestAgent);
+		rmapService.createDiSCO(disco1, reqEventDetails);
 
-		ResultBatch<URI> results = dataDisplayService.getAgentDiSCOs(requestAgent.getSystemAgent().toString(), 0);
+		ResultBatch<URI> results = dataDisplayService.getAgentDiSCOs(reqEventDetails.getSystemAgent().toString(), 0);
 		assertEquals(results.getResultList().size(),1);
 		assertEquals(results.getResultList().get(0).toString(),discoUri1.toString());
 
@@ -96,9 +96,9 @@ public class DataDisplayServiceImplTest extends WebDataRetrievalTestAbstract {
 		ORMapDiSCO disco2 = getRMapDiSCOObj(TestFile.DISCOA_XML);
 		String discoUri2 = disco2.getId().toString();
         assertNotNull(discoUri2);
-		rmapService.createDiSCO(disco2, requestAgent);
+		rmapService.createDiSCO(disco2, reqEventDetails);
 
-		results = dataDisplayService.getAgentDiSCOs(requestAgent.getSystemAgent().toString(), 0);
+		results = dataDisplayService.getAgentDiSCOs(reqEventDetails.getSystemAgent().toString(), 0);
 		assertEquals(results.getResultList().size(),2);
 		assertEquals(results.getResultList().get(0).toString(),discoUri1.toString());
 		assertEquals(results.getResultList().get(1).toString(),discoUri2.toString());
@@ -116,7 +116,7 @@ public class DataDisplayServiceImplTest extends WebDataRetrievalTestAbstract {
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOA_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
-		rmapService.createDiSCO(disco, requestAgent);
+		rmapService.createDiSCO(disco, reqEventDetails);
 
 		DiSCODTO discoDTO = dataDisplayService.getDiSCODTO(discoUri);
 		
@@ -145,12 +145,12 @@ public class DataDisplayServiceImplTest extends WebDataRetrievalTestAbstract {
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOA_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
-		RMapEvent event = rmapService.createDiSCO(disco, requestAgent);
+		RMapEvent event = rmapService.createDiSCO(disco, reqEventDetails);
 
 		EventDTO eventDTO = dataDisplayService.getEventDTO(event.getId().toString());
 		
-		assertEquals(eventDTO.getAssociatedAgent(), requestAgent.getSystemAgent().toString()); //0 because current version excluded
-		assertEquals(eventDTO.getAssociatedKey(), requestAgent.getAgentKeyId().toString());
+		assertEquals(eventDTO.getAssociatedAgent(), reqEventDetails.getSystemAgent().toString()); //0 because current version excluded
+		assertEquals(eventDTO.getAssociatedKey(), reqEventDetails.getAgentKeyId().toString());
 		assertEquals(eventDTO.getDescription(), null);
 		assertNotNull(eventDTO.getEndTime());
 		assertEquals(eventDTO.getResourcesAffected().size(),1);
@@ -170,7 +170,7 @@ public class DataDisplayServiceImplTest extends WebDataRetrievalTestAbstract {
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOB_V1_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
-		rmapService.createDiSCO(disco, requestAgent);
+		rmapService.createDiSCO(disco, reqEventDetails);
 		
 		//The following statements contain the URI we will search on... 
 		//	 <ore:aggregates rdf:resource="ark:/27927/56565656"/>
@@ -211,7 +211,7 @@ public class DataDisplayServiceImplTest extends WebDataRetrievalTestAbstract {
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOB_V1_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
-		rmapService.createDiSCO(disco, requestAgent);
+		rmapService.createDiSCO(disco, reqEventDetails);
 		String uriInDisco = "fakefake:uri";
 		dataDisplayService.getResourceBatch(uriInDisco, 0, PaginatorType.RESOURCE_GRAPH); //graph excludes literals
 	}
@@ -226,7 +226,7 @@ public class DataDisplayServiceImplTest extends WebDataRetrievalTestAbstract {
 		try {		
 			// now create DiSCO	
 			ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOA_XML);
-			rmapService.createDiSCO(disco, requestAgent);
+			rmapService.createDiSCO(disco, reqEventDetails);
 			String discoUri = disco.getId().toString();
 			
 			//ok now lets get a table of data


### PR DESCRIPTION
RMapRequestAgent is supplied to rmap-core when triplestore changes are made. It previously only contained systemAgentUri and keyUri. Both of these fields end up in the RMap Event corresponding to the change.  There wasn't previously a way for client apps to provide Event descriptions when they perform updates. This change expands RMapRequestAgent to include all client provided Event information (i.e. it adds the description field).  This allows client apps to put a description in the Event description field. This is being added to support work on hard-deletes through the admin tool since the GUI will allow admins to enter a note about the hard delete.