### PR TITLE
Update the SesameTriplestore to actually consult the underlying RepositoryConnection object to determine its status as "open" or "closed".

### DIFF
--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/triplestore/SesameTriplestore.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/triplestore/SesameTriplestore.java
@@ -422,7 +422,7 @@ public abstract class SesameTriplestore  {
 	 * @return true, if connection is open.
 	 */
 	public boolean hasConnectionOpen()	{
-		return (this.connectionOpen && connection!=null);
+		return (this.connectionOpen && connection!=null && connection.isOpen());
 	}
 		
 	/**

--- a/integration/src/test/java/info/rmapproject/integration/TriplestoreIT.java
+++ b/integration/src/test/java/info/rmapproject/integration/TriplestoreIT.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.integration;
+
+import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles({"default", "integration-triplestore", "inmemory-idservice", "inmemory-db"})
+@ContextConfiguration({"classpath*:/spring-rmapcore-context.xml"})
+public class TriplestoreIT {
+
+    @Autowired
+    private SesameTriplestore ts;
+
+    /**
+     * Insures that connections are properly opened from the integration-triplestore profile SesameTriplestore
+     * implementation.
+     */
+    @Test
+    public void testGetOpenConnection() {
+        assertFalse("Did not expect the triplestore to have an open connection.", ts.hasConnectionOpen());
+        assertTrue("Expected an open connection!", ts.getConnection().isOpen());
+        ts.closeConnection();
+        assertFalse("Expected the triplestore to have closed its connection", ts.hasConnectionOpen());
+    }
+}


### PR DESCRIPTION
The backstory is that I was developing an IT for the indexing-related code, and needed access to the triplestore `RepositoryConnection` to read in an `InputStream` of statements.  The `SesameTriplestore` instance gave me a `RepositoryConnection` but it was closed, which made no sense.  That is, I don't know why the connection would be closed upon request:

```java
rmapObjects.values().stream().flatMap(Set::stream).forEach(source -> {
             try (InputStream in = source.getInputStream();
                  RepositoryConnection c = triplestore.getConnection();) {
                  assertTrue(c.isOpen());
                 c.add(in, "http://foo/bar", source.getRdfFormat());
             } ...
```
The `assertTrue` was failing in the above codeblock without the fix supplied in this PR.

The way `SesameTriplestore` manages connections is not something I have time to reason about.  For example, why does it have a separate member variable to track the state of the connection when you can just ask the connection object itself?  

I don't have time to refactor or fully test what or why is going on, so this PR simply consults the status of the connection object itself, in addition to the existing conditions (e.g. on the status of the separate field for connection status).  It includes an IT to insure that no new behavior is introduced.