### PR TITLE
[DO NOT MERGE] Use property placeholder for the `hibernate.hbm2ddl.auto` Hibernate property.

### DIFF
--- a/auth/src/main/resources/inmemory-db.properties
+++ b/auth/src/main/resources/inmemory-db.properties
@@ -9,3 +9,4 @@ authdb.validationQuery=VALUES 1
 authdb.testOnBorrow=true
 authdb.hibernate.dialect=org.hibernate.dialect.DerbyTenSevenDialect
 authdb.hibernate.show_sql=true
+authdb.hibernate.hbm2ddl.auto=update

--- a/auth/src/main/resources/persistent-db.properties
+++ b/auth/src/main/resources/persistent-db.properties
@@ -10,3 +10,4 @@ authdb.validationQuery=SELECT 1
 authdb.testOnBorrow=true
 authdb.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 authdb.hibernate.show_sql=false
+authdb.hibernate.hbm2ddl.auto=none

--- a/auth/src/main/resources/rmapauth.properties
+++ b/auth/src/main/resources/rmapauth.properties
@@ -9,3 +9,16 @@ rmapauth.authIdPrefix=rmap:/authid/
 # The base URL is used to construct paths that require the RMap website as a prefix.
 # Should not include a trailing forward-slash  
 rmapauth.baseUrl=https\://[yourRMapWebServerName]
+
+# Actions, if any, hibernate should take on the database schema when instantiating a session factory
+# Valid values are:
+#  'none'          No action will be performed.
+#  'create-only'   Database creation will be generated.
+#  'drop'          Database dropping will be generated.
+#  'create'        Database dropping will be generated followed by database creation.
+#  'create-drop'   Drop the schema and recreate it on SessionFactory startup. Additionally, drop the schema on
+#                  SessionFactory shutdown.
+#  'validate'      Validate the database schema
+#  'update'        Update the database schema
+# (http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#configurations-hbmddl)
+authdb.hibernate.hbm2ddl.auto = none

--- a/auth/src/main/resources/spring-rmapauth-context.xml
+++ b/auth/src/main/resources/spring-rmapauth-context.xml
@@ -32,8 +32,10 @@
             <props>
                 <prop key="hibernate.dialect">${authdb.hibernate.dialect}</prop>
                 <prop key="hibernate.show_sql">${authdb.hibernate.show_sql}</prop>
+                <prop key="hibernate.hbm2ddl.auto">${authdb.hibernate.hbm2ddl.auto}</prop>
             </props>
         </property>
+
     </bean>
 
     <!-- unit tests -->

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -20,7 +20,6 @@
         <sesame.workbench.context>/openrdf-workbench</sesame.workbench.context>
         <sesamehttp.repository.name>its</sesamehttp.repository.name>
         <derby.home>${project.build.testOutputDirectory}/derby</derby.home>
-        <hibernate.hbm2ddl.auto>update</hibernate.hbm2ddl.auto>
     </properties>
 
     <dependencies>
@@ -230,7 +229,6 @@
                             <sesamehttp.workbench.url>http://localhost:${rmap.webapp.test.port}/openrdf-workbench</sesamehttp.workbench.url>
                             <spring.profiles.active>default,integration-db,inmemory-idservice,integration-triplestore</spring.profiles.active>
                             <info.aduna.platform.appdata.basedir>${project.build.testOutputDirectory}/sesame</info.aduna.platform.appdata.basedir>
-                            <hibernate.hbm2ddl.auto>${hibernate.hbm2ddl.auto}</hibernate.hbm2ddl.auto>
                         </systemProperties>
                         <dependencies>
                             <dependency>

--- a/integration/src/main/resources/integration-db.properties
+++ b/integration/src/main/resources/integration-db.properties
@@ -10,3 +10,4 @@ authdb.testOnBorrow=true
 authdb.hibernate.dialect=org.hibernate.dialect.DerbyTenSevenDialect
 authdb.hibernate.show_sql=false
 authdb.preserve = true
+authdb.hibernate.hbm2ddl.auto = update


### PR DESCRIPTION
Allows each database implementation (in-memory, integration, production) to define Hibernate behavior with regard to schema generation.  The default behavior is to do nothing.  These settings are consistent with existing behavior.  Note: requires Hibernate 5, so it should not be merged yet (until the indexing code goes in).