### PR TITLE
Removed constraint on stmts being rooted to Aggregated resources

### DIFF
--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapDiSCO.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapDiSCO.java
@@ -23,9 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import info.rmapproject.core.idservice.IdService;
 import org.openrdf.model.BNode;
 import org.openrdf.model.IRI;
 import org.openrdf.model.Model;
@@ -38,6 +36,7 @@ import org.openrdf.model.vocabulary.DCTERMS;
 
 import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
+import info.rmapproject.core.idservice.IdService;
 import info.rmapproject.core.model.RMapIri;
 import info.rmapproject.core.model.RMapObjectType;
 import info.rmapproject.core.model.RMapResource;
@@ -106,73 +105,6 @@ public class ORMapDiSCO extends ORMapObject implements RMapDiSCO {
 		this(id);
 		this.setCreator(creator);
 		this.setAggregatedResources(aggregatedResources);
-	}
-
-	/**
-	 * Convenience class for making + checking graph of statements.
-	 *
-	 * @author smorrissey
-	 */
-	class Node {
-
-		/** The neighbors. */
-		List<Node> neighbors;
-
-		/** The was visited. */
-		boolean wasVisited;
-
-		/**
-		 * Instantiates a new node.
-		 */
-		Node(){
-			this.neighbors = new ArrayList<Node>();
-			wasVisited = false;
-		}
-
-		/**
-		 * Gets the neighbors.
-		 *
-		 * @return the neighbors
-		 */
-		List<Node> getNeighbors(){
-			return neighbors;
-		}
-
-		/**
-		 * Was visited.
-		 *
-		 * @return true, if successful
-		 */
-		boolean wasVisited(){
-			return wasVisited;
-		}
-
-		/**
-		 * Sets the was visited.
-		 *
-		 * @param isVisited the new was visited
-		 */
-		void setWasVisited(boolean isVisited){
-			wasVisited = isVisited;
-		}
-	}
-
-	/**
-	 * Recursive visit to nodes to mark as visited.
-	 *
-	 * @param visitedNodes the visited nodes
-	 * @param startNode the start node
-	 */
-	protected void markConnected (Set<Node> visitedNodes,
-		Node startNode){
-		startNode.setWasVisited(true);
-		visitedNodes.add(startNode);
-		for (Node neighbor:startNode.getNeighbors()){
-			if (! neighbor.wasVisited()){
-				this.markConnected(visitedNodes, neighbor);
-			}
-		}
-		return;
 	}
 
 	/* (non-Javadoc)

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapDiscoTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapDiscoTest.java
@@ -200,40 +200,6 @@ public class ORMapDiscoTest extends CoreTestAbstract {
 	}
 
 	/**
-	 * Test method for {@link info.rmapproject.core.model.impl.openrdf.ORMapDiSCO#isConnectedGraph(java.util.List)}.
-	 */
-	@Test
-	public void testIsConnectedGraph() {
-		ORMapDiSCO disco = new ORMapDiSCO(uri2OpenRdfIri(create("http://example.org/disco/" + counter.getAndIncrement())));
-		Statement rStmt = vf.createStatement(disco.context, ORE.AGGREGATES, r,disco.context);
-		Statement rStmt2 = vf.createStatement(disco.context, ORE.AGGREGATES, r2,disco.context);
-		disco.aggregatedResources = new ArrayList<Statement>();
-		disco.aggregatedResources.add(rStmt);
-		disco.aggregatedResources.add(rStmt2);
-		relatedStmts.add(s1);
-		relatedStmts.add(s2);
-		relatedStmts.add(s3);
-		relatedStmts.add(s4);
-		boolean isConnected = OStatementsAdapter.isConnectedGraph(disco, relatedStmts);
-		assertTrue (isConnected);
-		// second test disjoint r->a  b->c
-		relatedStmts.remove(s2);
-		relatedStmts.remove(s4);
-		isConnected = OStatementsAdapter.isConnectedGraph(disco, relatedStmts);
-		assertFalse(isConnected);
-		// third test connected r->a  b->c r2->c c->b, handles cycle, duplicates
-		Statement s5 = vf.createStatement(r2,RMAP.DERIVEDOBJECT,c);
-		Statement s6 = vf.createStatement(c,RMAP.DERIVEDOBJECT,b);
-		Statement s7 = vf.createStatement(c,RMAP.DERIVEDOBJECT,b);
-		relatedStmts.add(s6);
-		relatedStmts.add(s5);
-		relatedStmts.add(s7);
-		isConnected = OStatementsAdapter.isConnectedGraph(disco, relatedStmts);
-		assertTrue (isConnected);
-	}
-
-
-	/**
 	 * Test method for {@link info.rmapproject.core.model.impl.openrdf.ORMapDiSCO#getAggregatedResourceStatements()}.
 	 */
 	@Test

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/OStatementsAdapterTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/OStatementsAdapterTest.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a 
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.core.rmapservice.impl.openrdf;
+
+import static java.net.URI.create;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.openrdf.model.Resource;
+import org.openrdf.model.Statement;
+import org.openrdf.model.Value;
+import org.openrdf.model.ValueFactory;
+
+import info.rmapproject.core.CoreTestAbstract;
+import info.rmapproject.core.exception.RMapException;
+import info.rmapproject.core.model.impl.openrdf.ORAdapter;
+import info.rmapproject.core.model.impl.openrdf.ORMapDiSCO;
+import info.rmapproject.core.model.impl.openrdf.OStatementsAdapter;
+import info.rmapproject.core.rdfhandler.RDFType;
+import info.rmapproject.core.rdfhandler.impl.openrdf.RioRDFHandler;
+import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
+import info.rmapproject.testdata.service.TestDataHandler;
+import info.rmapproject.testdata.service.TestFile;
+
+public class OStatementsAdapterTest extends CoreTestAbstract {
+
+	//TODO: the asDisco tests are quick tests to catch exceptions, this does not do a full validation of results - need to add better validation
+	
+	private static final AtomicInteger counter = new AtomicInteger();
+		
+	/**
+	 * Test method for {@link info.rmapproject.core.model.impl.openrdf.OStatementsAdapter#asDisco(java.util.List, Supplier<URI>)}.
+	 * Runs a valid DiSCO through the asDisco process
+	 */
+	@Test
+	public void testAsDiscoValidDisco1() throws Exception {
+		InputStream stream = TestDataHandler.getTestData(TestFile.DISCOA_JSONLD);
+		RioRDFHandler handler = new RioRDFHandler();	
+		Set<Statement>stmts = handler.convertRDFToStmtList(stream, RDFType.get(TestFile.DISCOA_JSONLD.getType()), "");
+		ORMapDiSCO disco = OStatementsAdapter.asDisco(stmts,
+				() -> create("http://example.org/disco/" + counter.getAndIncrement()));
+		assertTrue(disco!=null);	
+	}
+	
+	/**
+	 * Test method for {@link info.rmapproject.core.model.impl.openrdf.OStatementsAdapter#asDisco(java.util.List, Supplier<URI>)}.
+	 * Runs a valid DiSCO through the asDisco process
+	 */
+	@Test
+	public void testAsDiscoValidDisco2() throws Exception {
+		InputStream stream = TestDataHandler.getTestData(TestFile.DISCOB_V1_XML);
+		RioRDFHandler handler = new RioRDFHandler();	
+		Set<Statement>stmts = handler.convertRDFToStmtList(stream, RDFType.get(TestFile.DISCOB_V1_XML.getType()), "");
+		ORMapDiSCO disco = OStatementsAdapter.asDisco(stmts,
+				() -> create("http://example.org/disco/" + counter.getAndIncrement()));
+		assertTrue(disco!=null);
+	}
+	
+	
+	/**
+	 * Test method for {@link info.rmapproject.core.model.impl.openrdf.OStatementsAdapter#asDisco(java.util.List, Supplier<URI>)}.
+	 * Runs a DiSCO with a graph that is not connected through the asDisco process - looks for exception
+	 */
+	@Test
+	public void testAsDiscoInvalidDiSCO() throws Exception {
+		try {
+			InputStream stream = TestDataHandler.getTestData(TestFile.DISCOA_XML_NOT_CONNECTED);
+			RioRDFHandler handler = new RioRDFHandler();	
+			Set<Statement>stmts = handler.convertRDFToStmtList(stream, RDFType.get(TestFile.DISCOA_XML_NOT_CONNECTED.getType()), "");
+			OStatementsAdapter.asDisco(stmts,
+					() -> create("http://example.org/disco/" + counter.getAndIncrement()));
+			fail("should have thrown not connected graph error");
+		} catch (RMapException ex) {
+			//error expected, check it's the right one
+			assertTrue(ex.getMessage().contains("do not form a connected graph"));			
+		}
+	}
+	
+	/**
+	 * Test method for {@link info.rmapproject.core.model.impl.openrdf.OStatementsAdapter#asDisco(java.util.List, Supplier<URI>)}.
+	 * Runs a DiSCO with a graph that has a non-aggregate root i.e. there is a x -> aggregatedResource connection in the graph
+	 */
+	@Test
+	public void testAsDiscoValidDiSCOWithNonAggregateRoot() throws Exception {
+		InputStream stream = TestDataHandler.getTestData(TestFile.DISCOA_TURTLE_NON_AGGREGATE_ROOTS);
+		RioRDFHandler handler = new RioRDFHandler();	
+		Set<Statement>stmts = handler.convertRDFToStmtList(stream, RDFType.get(TestFile.DISCOA_TURTLE_NON_AGGREGATE_ROOTS.getType()), "");
+		ORMapDiSCO disco = OStatementsAdapter.asDisco(stmts,
+				() -> create("http://example.org/disco/" + counter.getAndIncrement()));
+		assertTrue(disco!=null);
+	}
+	
+	/**
+	 * Test method for {@link info.rmapproject.core.model.impl.openrdf.ORMapDiSCO#isConnectedGraph(java.util.List,java.util.List)}.
+	 * Checks that a disconnected graph detected, and valid graphs come back as connected.
+	 */
+	@Test
+	public void testIsConnectedGraph() throws Exception {
+		ValueFactory vf = ORAdapter.getValueFactory();
+		
+		Resource agg1 = vf.createIRI("http://rmap-info.org");	
+		Resource agg2 = vf.createIRI("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki");
+		
+		List<URI> aggregatedResources = new ArrayList<URI>();
+		aggregatedResources.add(new URI(agg1.toString()));
+		aggregatedResources.add(new URI(agg2.toString()));
+		
+		Value litA = vf.createLiteral("a");
+		Resource resB = vf.createIRI("http://b.org");
+		Resource resC = vf.createIRI("http://c.org");
+		Resource resD = vf.createIRI("http://d.org");		
+		Resource resE = vf.createIRI("http://e.org");		
+		
+		List<Statement> relatedStmts = new ArrayList<Statement>();
+		
+		//predicates are nonsense here
+		// first test connected r->a r->b b->c b->d
+		Statement s1 = vf.createStatement(agg1,RMAP.DERIVEDOBJECT,litA);
+		Statement s2 = vf.createStatement(agg1,RMAP.DERIVEDOBJECT,resB);
+		Statement s3 = vf.createStatement(resB,RMAP.DERIVEDOBJECT,resC);
+		Statement s4 = vf.createStatement(resB,RMAP.DERIVEDOBJECT,resD);
+		relatedStmts.add(s1);
+		relatedStmts.add(s2);
+		relatedStmts.add(s3);
+		relatedStmts.add(s4);
+		boolean isConnected = OStatementsAdapter.isConnectedGraph(aggregatedResources, relatedStmts);
+		assertTrue (isConnected);
+		
+		// second test disjoint r->a  b->c
+		relatedStmts.remove(s2);
+		relatedStmts.remove(s4);
+		isConnected = OStatementsAdapter.isConnectedGraph(aggregatedResources, relatedStmts);
+		assertFalse(isConnected);
+		
+		// third test connected r->a  b->c r2->c c->b, handles cycle, duplicates
+		Statement s5 = vf.createStatement(agg2,RMAP.DERIVEDOBJECT,resC);
+		Statement s6 = vf.createStatement(resC,RMAP.DERIVEDOBJECT,resB);
+		Statement s7 = vf.createStatement(resC,RMAP.DERIVEDOBJECT,resB);
+		relatedStmts.add(s6);
+		relatedStmts.add(s5);
+		relatedStmts.add(s7);
+		isConnected = OStatementsAdapter.isConnectedGraph(aggregatedResources, relatedStmts);
+		assertTrue (isConnected);
+
+		// fourth test connected handles stmt that directs TO the aggregated resource
+		Statement s8 = vf.createStatement(resE,RMAP.DERIVEDOBJECT,resC);
+		relatedStmts.add(s8);
+		isConnected = OStatementsAdapter.isConnectedGraph(aggregatedResources, relatedStmts);
+		assertTrue (isConnected);
+	}
+
+}

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/OStatementsAdapterTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/OStatementsAdapterTest.java
@@ -21,6 +21,7 @@ package info.rmapproject.core.rmapservice.impl.openrdf;
 
 import static java.net.URI.create;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -48,6 +49,11 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
 import info.rmapproject.testdata.service.TestDataHandler;
 import info.rmapproject.testdata.service.TestFile;
 
+/**
+ * Tests for OStatementAdapter
+ * @author khanson
+ *
+ */
 public class OStatementsAdapterTest extends CoreTestAbstract {
 
 	//TODO: the asDisco tests are quick tests to catch exceptions, this does not do a full validation of results - need to add better validation
@@ -65,7 +71,7 @@ public class OStatementsAdapterTest extends CoreTestAbstract {
 		Set<Statement>stmts = handler.convertRDFToStmtList(stream, RDFType.get(TestFile.DISCOA_JSONLD.getType()), "");
 		ORMapDiSCO disco = OStatementsAdapter.asDisco(stmts,
 				() -> create("http://example.org/disco/" + counter.getAndIncrement()));
-		assertTrue(disco!=null);	
+		assertNotNull(disco);	
 	}
 	
 	/**
@@ -79,7 +85,7 @@ public class OStatementsAdapterTest extends CoreTestAbstract {
 		Set<Statement>stmts = handler.convertRDFToStmtList(stream, RDFType.get(TestFile.DISCOB_V1_XML.getType()), "");
 		ORMapDiSCO disco = OStatementsAdapter.asDisco(stmts,
 				() -> create("http://example.org/disco/" + counter.getAndIncrement()));
-		assertTrue(disco!=null);
+		assertNotNull(disco);
 	}
 	
 	
@@ -113,7 +119,7 @@ public class OStatementsAdapterTest extends CoreTestAbstract {
 		Set<Statement>stmts = handler.convertRDFToStmtList(stream, RDFType.get(TestFile.DISCOA_TURTLE_NON_AGGREGATE_ROOTS.getType()), "");
 		ORMapDiSCO disco = OStatementsAdapter.asDisco(stmts,
 				() -> create("http://example.org/disco/" + counter.getAndIncrement()));
-		assertTrue(disco!=null);
+		assertNotNull(disco);
 	}
 	
 	/**

--- a/testdata/src/main/java/info/rmapproject/testdata/service/TestFile.java
+++ b/testdata/src/main/java/info/rmapproject/testdata/service/TestFile.java
@@ -74,7 +74,10 @@ public enum TestFile {
 
 	/** DiSCO "A" as XML with no additional statements or aggregates*/
 	DISCOA_XML_NO_BODY_NO_AGGREGATES("/discos/discoA_nobody_noaggregates.rdf","RDFXML"),
-		
+
+	/** DiSCO "A" as turtle with some inverse relationships that form new roots and break the directionality of the DiSCO
+	 * Can be used to check any connected graph OK even if it's not a one directional graph rooted from aggregates*/
+	DISCOA_TURTLE_NON_AGGREGATE_ROOTS("/discos/discoA_nonaggregateroots.ttl","TURTLE"),
 	
 	/** Based on Portico data, working DiSCO "B" version 1, use for tests where you just want a working 
 	 *  DiSCO. This DiSCO contains 1 aggregated resource, 3 authors (2 BNodes, one with ORCID), a 

--- a/testdata/src/main/resources/discos/discoA_nonaggregateroots.ttl
+++ b/testdata/src/main/resources/discos/discoA_nonaggregateroots.ttl
@@ -1,0 +1,55 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix prism: <http://prismstandard.org/namespaces/basic/2.0/> .
+@prefix cito: <http://purl.org/spar/cito/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ieee: <http://data.ieee.org/ieee/terms/> .
+@prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix rmap: <http://purl.org/ontology/rmap#> .
+
+[] a <http://purl.org/ontology/rmap#DiSCO> ;
+	dcterms:creator <http://isni.org/isni/0000000122976723> ;
+	dc:description "This is a made up example of an IEEE DiSCO." ;
+	ore:aggregates <http://doi.org/10.1109/disco.test> ;
+	ore:aggregates <http://ieeexplore.ieee.org/example/000000-mm.zip> .
+
+<http://doi.org/10.1109/disco.test> 
+	a <http://purl.org/spar/fabio/ConferencePaper> ;
+	dcterms:identifier <ark:/35911/amsid/111111>, <ark:/35911/idams/1b1b1b1b1b1b> ;
+	ieee:content-type "orig-research" ;
+	ieee:inspec-accession-number "123456789" ;
+	dcterms:isPartOf <ark:/35911/amsid/222222>, <urn:isbn:9781467326322>, <urn:isbn:9781467326315> , <ark:/35911/amsid/333333> ;
+	dc:hasPart <http://ieeexplore.ieee.org/example/000000-mm.zip> ;
+	
+	dc:creator "Brown, A." ;
+	dc:creator "Green, M." ;
+	dc:creator "White, D." ;
+	dc:creator "Black, B." ;
+				
+	dc:title "Made up article about GPUs" ;
+	prism:doi <doi:10.1109/discoa.test> ;	
+	
+	cito:isCitedBy <http://dx.doi.org/10.1109/111111> ;
+	dc:subject "storage management", "resource allocation" , "fragmentation",
+					"massively parallel dynamic memory allocation", 
+					"resource management", "graphics processing units" . 
+					
+<http://ieeexplore.ieee.org/example/000000-mm.zip>
+	dc:format "application" ;
+	dc:description "Zip file containing AVI movie and README file in Word format" ;
+	dc:hasPart <http://ieeexplore.ieee.org/example/000000-mm.zip#video.avi> ;
+	dc:hasPart <http://ieeexplore.ieee.org/example/000000-mm.zip#README.docx> .
+
+<http://ieeexplore.ieee.org/example/000000-mm.zip#video.avi>
+	dc:format "video/x-msvideo" ;
+	dc:extent "194KB" .
+
+<http://doi.org/10.1109/another.paper> 
+	cito:cites <http://doi.org/10.1109/disco.test> ;
+	dc:description "A paper that cites one of the aggregated resources" .
+	
+<http://doi.org/10.0000/video.doi>
+	dcterms:identifier <http://ieeexplore.ieee.org/example/000000-mm.zip#video.avi> .
+	
+
+	


### PR DESCRIPTION
- Closes issue #85.  See issue for full details of change
- Moved logic for checking connected resources to OStatementsAdapter - the only place it is used.   Removed it from ORMapDiSCO.
- Added a few tests for OStatementAdapter. The ones for asDisco just check for exceptions, left a todo to add content checks for these