### PR TITLE
Add lineage progenitor to core model

### DIFF
--- a/core/src/main/java/info/rmapproject/core/model/RMapLiteral.java
+++ b/core/src/main/java/info/rmapproject/core/model/RMapLiteral.java
@@ -19,6 +19,9 @@
  *******************************************************************************/
 package info.rmapproject.core.model;
 
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * Models the concept of an RDF Literal.  Literals have a string value. 
  * They can also optionally have a language and datatype
@@ -60,8 +63,7 @@ public class RMapLiteral implements RMapValue {
 	 * Instantiates a new RMap literal.
 	 *
 	 * @param value the value
-	 * @param language the language (can be null)
-	 * @throws IllegalArgumentException if value argument is null
+	 * @param language the language (can be null).
 	 */
 	public RMapLiteral(String value, String language){
 		this();
@@ -136,6 +138,26 @@ public class RMapLiteral implements RMapValue {
 	@Override
 	public String toString(){
 		return getStringValue();
+	}
+	
+	public boolean equals(Object o) {
+	    if (o != null && o instanceof RMapLiteral) {
+	        RMapLiteral that = (RMapLiteral) o;
+	        
+	        return value.equals(that.value)
+	                && Optional.ofNullable(language)
+	                        .map(l -> l.equals(that.language))
+	                        .orElse(that.language == null)
+	                && Optional.ofNullable(datatype)
+	                        .map(d -> d.equals(that.datatype))
+	                        .orElse(that.datatype == null);
+	    }
+	    
+	    return false;
+	}
+	
+	public int hashCode() {
+	    return Objects.hash(value, language, datatype);
 	}
 
 }

--- a/core/src/main/java/info/rmapproject/core/model/event/RMapEvent.java
+++ b/core/src/main/java/info/rmapproject/core/model/event/RMapEvent.java
@@ -107,5 +107,19 @@ public interface RMapEvent extends RMapObject{
 	 */
 	public void setDescription(RMapValue description) throws RMapException;
 	
+	/**
+	 * Gets the IRI of the lineage progenitor DiSCO, if applicable
+	 *
+	 * @return lineage progenitor DiSCO IRI, or null if not applicable.
+	 * @throws RMapException
+	 */
+	public RMapIri getLineageProgenitor() throws RMapException;
 	
+	/**
+	 * Sets the ID of the lineage progenitor DiSCOe.
+	 *
+	 * @param iri IRI of the lineage progenitor DiSCO.
+	 * @throws RMapException
+	 */
+	public void setLineageProgenitor(RMapIri iri) throws RMapException;
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
@@ -430,6 +430,14 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	public Statement getEndTimeStmt(){
 		return this.endTimeStmt;
 	}
+	
+	/** Get the lineage progenitor statement.
+	 * 
+	 * @return the statement containing the lineage progenitor.
+	 */
+	public Statement getLineageProgenitorStmt() {
+	    return this.lineageStmt;
+	}
 
 	/* (non-Javadoc)
 	 * @see info.rmapproject.core.model.RMapEvent#setEndTime(java.util.Date)
@@ -489,10 +497,13 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	
 	@Override
 	public void setLineageProgenitor(RMapIri lineageiri) {
-	    this.lineageStmt = ORAdapter.getValueFactory().createStatement(
-	            this.context,
-	            RMAP.LINEAGE_PROGENITOR, 
-	            ORAdapter.rMapIri2OpenRdfIri(lineageiri));
+	    if (lineageiri != null) {
+	        this.lineageStmt = ORAdapter.getValueFactory().createStatement(
+	                this.context,
+	                RMAP.LINEAGE_PROGENITOR, 
+	                ORAdapter.rMapIri2OpenRdfIri(lineageiri), 
+	                this.context);
+	    }
 	}
 	
 	@Override
@@ -523,6 +534,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 		if (startTimeStmt != null ? !startTimeStmt.equals(that.startTimeStmt) : that.startTimeStmt != null)
 			return false;
 		if (endTimeStmt != null ? !endTimeStmt.equals(that.endTimeStmt) : that.endTimeStmt != null) return false;
+		if (lineageStmt != null ? !lineageStmt.equals(that.lineageStmt) : that.lineageStmt != null) return false;
 		return associatedKeyStmt != null ? associatedKeyStmt.equals(that.associatedKeyStmt) : that.associatedKeyStmt == null;
 	}
 
@@ -536,6 +548,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 		result = 31 * result + (startTimeStmt != null ? startTimeStmt.hashCode() : 0);
 		result = 31 * result + (endTimeStmt != null ? endTimeStmt.hashCode() : 0);
 		result = 31 * result + (associatedKeyStmt != null ? associatedKeyStmt.hashCode() : 0);
+		result = 31 * result + (lineageStmt != null ? lineageStmt.hashCode() : 0);
 		return result;
 	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
@@ -24,6 +24,7 @@ package info.rmapproject.core.model.impl.openrdf;
 
 import java.net.URI;
 import java.util.Date;
+import java.util.Optional;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -77,6 +78,9 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	
 	/** The associated key stmt. */
 	protected Statement associatedKeyStmt; // set by constructor
+	
+	/** The optional lineage stmt */
+	protected Statement lineageStmt;
    
 	/**
 	 * Instantiates a new ORMapEvent.
@@ -92,13 +96,14 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	 * @param context the context
 	 * @param typeStatement the type statement
 	 * @param associatedKeyStmt the associated key stmt
+	 * @param lineageStmt the associated lineage stmt; nullable
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
 	protected  ORMapEvent(Statement eventTypeStmt, Statement eventTargetTypeStmt, 
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
-			Statement typeStatement, Statement associatedKeyStmt) 
+			Statement typeStatement, Statement associatedKeyStmt, Statement lineageStmt) 
 					throws RMapException, RMapDefectiveArgumentException {
 		super(context);
 		this.eventTypeStmt = eventTypeStmt;
@@ -108,6 +113,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 		this.startTimeStmt = startTimeStmt;
 		this.endTimeStmt = endTimeStmt;
 		this.associatedKeyStmt = associatedKeyStmt;
+		this.lineageStmt = lineageStmt;
 		setTypeStatement(RMapObjectType.EVENT);
 	}
 	
@@ -479,6 +485,23 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 			eventModel.add(associatedKeyStmt);
 		}
 		return eventModel;
+	}
+	
+	@Override
+	public void setLineageProgenitor(RMapIri lineageiri) {
+	    this.lineageStmt = ORAdapter.getValueFactory().createStatement(
+	            this.context,
+	            RMAP.LINEAGE_PROGENITOR, 
+	            ORAdapter.rMapIri2OpenRdfIri(lineageiri));
+	}
+	
+	@Override
+	public RMapIri getLineageProgenitor() {
+	    return Optional.ofNullable(lineageStmt)
+	            .map(Statement::getObject)
+	            .map(value -> (IRI) value)
+	            .map(ORAdapter::openRdfIri2RMapIri)
+	            .orElse(null);
 	}
 
 	@Override

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEvent.java
@@ -79,8 +79,8 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	/** The associated key stmt. */
 	protected Statement associatedKeyStmt; // set by constructor
 	
-	/** The optional lineage stmt */
-	protected Statement lineageStmt;
+	/** The optional lineage progenitor stmt */
+	protected Statement lineageProgenitorStmt;
    
 	/**
 	 * Instantiates a new ORMapEvent.
@@ -96,14 +96,14 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	 * @param context the context
 	 * @param typeStatement the type statement
 	 * @param associatedKeyStmt the associated key stmt
-	 * @param lineageStmt the associated lineage stmt; nullable
+	 * @param lineageProgenitorStmt the associated lineage stmt; nullable
 	 * @throws RMapException the RMap exception
 	 * @throws RMapDefectiveArgumentException 
 	 */
 	protected  ORMapEvent(Statement eventTypeStmt, Statement eventTargetTypeStmt, 
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
-			Statement typeStatement, Statement associatedKeyStmt, Statement lineageStmt) 
+			Statement typeStatement, Statement associatedKeyStmt, Statement lineageProgenitorStmt) 
 					throws RMapException, RMapDefectiveArgumentException {
 		super(context);
 		this.eventTypeStmt = eventTypeStmt;
@@ -113,7 +113,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 		this.startTimeStmt = startTimeStmt;
 		this.endTimeStmt = endTimeStmt;
 		this.associatedKeyStmt = associatedKeyStmt;
-		this.lineageStmt = lineageStmt;
+		this.lineageProgenitorStmt = lineageProgenitorStmt;
 		setTypeStatement(RMapObjectType.EVENT);
 	}
 	
@@ -436,7 +436,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	 * @return the statement containing the lineage progenitor.
 	 */
 	public Statement getLineageProgenitorStmt() {
-	    return this.lineageStmt;
+	    return this.lineageProgenitorStmt;
 	}
 
 	/* (non-Javadoc)
@@ -498,7 +498,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	@Override
 	public void setLineageProgenitor(RMapIri lineageiri) {
 	    if (lineageiri != null) {
-	        this.lineageStmt = ORAdapter.getValueFactory().createStatement(
+	        this.lineageProgenitorStmt = ORAdapter.getValueFactory().createStatement(
 	                this.context,
 	                RMAP.LINEAGE_PROGENITOR, 
 	                ORAdapter.rMapIri2OpenRdfIri(lineageiri), 
@@ -508,7 +508,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 	
 	@Override
 	public RMapIri getLineageProgenitor() {
-	    return Optional.ofNullable(lineageStmt)
+	    return Optional.ofNullable(lineageProgenitorStmt)
 	            .map(Statement::getObject)
 	            .map(value -> (IRI) value)
 	            .map(ORAdapter::openRdfIri2RMapIri)
@@ -534,7 +534,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 		if (startTimeStmt != null ? !startTimeStmt.equals(that.startTimeStmt) : that.startTimeStmt != null)
 			return false;
 		if (endTimeStmt != null ? !endTimeStmt.equals(that.endTimeStmt) : that.endTimeStmt != null) return false;
-		if (lineageStmt != null ? !lineageStmt.equals(that.lineageStmt) : that.lineageStmt != null) return false;
+		if (lineageProgenitorStmt != null ? !lineageProgenitorStmt.equals(that.lineageProgenitorStmt) : that.lineageProgenitorStmt != null) return false;
 		return associatedKeyStmt != null ? associatedKeyStmt.equals(that.associatedKeyStmt) : that.associatedKeyStmt == null;
 	}
 
@@ -548,7 +548,7 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 		result = 31 * result + (startTimeStmt != null ? startTimeStmt.hashCode() : 0);
 		result = 31 * result + (endTimeStmt != null ? endTimeStmt.hashCode() : 0);
 		result = 31 * result + (associatedKeyStmt != null ? associatedKeyStmt.hashCode() : 0);
-		result = 31 * result + (lineageStmt != null ? lineageStmt.hashCode() : 0);
+		result = 31 * result + (lineageProgenitorStmt != null ? lineageProgenitorStmt.hashCode() : 0);
 		return result;
 	}
 }

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreation.java
@@ -72,10 +72,10 @@ public class ORMapEventCreation extends ORMapEventWithNewObjects implements RMap
 	public ORMapEventCreation(Statement eventTypeStmt, Statement eventTargetTypeStmt, 
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
-			Statement typeStatement, Statement associatedKeyStmt, List<Statement> createdObjects) 
+			Statement typeStatement, Statement associatedKeyStmt, Statement lineage, List<Statement> createdObjects) 
 					throws RMapException {
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);
 		this.createdObjects = createdObjects;
 	}
 	

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
@@ -77,10 +77,10 @@ public class ORMapEventDeletion extends ORMapEvent implements RMapEventDeletion 
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt, 
-			Statement lineage, Statement deleted) throws RMapException, RMapDefectiveArgumentException {
+			Statement lineageProgenitor, Statement deleted) throws RMapException, RMapDefectiveArgumentException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageProgenitor);
 		this.deleted = deleted;
 	}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
@@ -77,10 +77,10 @@ public class ORMapEventDeletion extends ORMapEvent implements RMapEventDeletion 
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt, 
-			Statement deleted) throws RMapException, RMapDefectiveArgumentException {
+			Statement deleted, Statement lineage) throws RMapException, RMapDefectiveArgumentException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);
 		this.deleted = deleted;
 	}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletion.java
@@ -77,7 +77,7 @@ public class ORMapEventDeletion extends ORMapEvent implements RMapEventDeletion 
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt, 
-			Statement deleted, Statement lineage) throws RMapException, RMapDefectiveArgumentException {
+			Statement lineage, Statement deleted) throws RMapException, RMapDefectiveArgumentException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
 				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
@@ -108,11 +108,11 @@ public class ORMapEventDerivation extends ORMapEventWithNewObjects implements
 	public ORMapEventDerivation(Statement eventTypeStmt, Statement eventTargetTypeStmt, 
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
-			Statement typeStatement, Statement associatedKeyStmt, List<Statement> createdObjects,
-			Statement derivationStatement, Statement sourceObjectStatement) 
+			Statement typeStatement, Statement associatedKeyStmt, Statement lineageStmnt, 
+			List<Statement> createdObjects, Statement derivationStatement, Statement sourceObjectStatement) 
 	throws RMapException {
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageStmnt);
 		
 		if (createdObjects==null || createdObjects.size()==0){
 			throw new RMapException ("Null or empty list of created object in Update");

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivation.java
@@ -108,11 +108,11 @@ public class ORMapEventDerivation extends ORMapEventWithNewObjects implements
 	public ORMapEventDerivation(Statement eventTypeStmt, Statement eventTargetTypeStmt, 
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
-			Statement typeStatement, Statement associatedKeyStmt, Statement lineageStmnt, 
+			Statement typeStatement, Statement associatedKeyStmt, Statement lineageProgenitorStmnt, 
 			List<Statement> createdObjects, Statement derivationStatement, Statement sourceObjectStatement) 
 	throws RMapException {
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageStmnt);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageProgenitorStmnt);
 		
 		if (createdObjects==null || createdObjects.size()==0){
 			throw new RMapException ("Null or empty list of created object in Update");

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
@@ -68,7 +68,7 @@ public class ORMapEventInactivation extends ORMapEvent implements
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
 			Statement typeStatement, Statement associatedKeyStmt, 
-			Statement inactivatedObjectStatement, Statement lineage) 
+			Statement lineage, Statement inactivatedObjectStatement) 
 	throws RMapException {
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
 				startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt, lineage);

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
@@ -25,7 +25,6 @@ package info.rmapproject.core.model.impl.openrdf;
 import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.model.RMapIri;
-import info.rmapproject.core.model.RMapValue;
 import info.rmapproject.core.model.event.RMapEventInactivation;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
@@ -68,10 +67,11 @@ public class ORMapEventInactivation extends ORMapEvent implements
 	public ORMapEventInactivation(Statement eventTypeStmt, Statement eventTargetTypeStmt, 
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
-			Statement typeStatement, Statement associatedKeyStmt, Statement inactivatedObjectStatement) 
+			Statement typeStatement, Statement associatedKeyStmt, 
+			Statement inactivatedObjectStatement, Statement lineage) 
 	throws RMapException {
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt);
+				startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt, lineage);
 		if (inactivatedObjectStatement==null){
 			throw new RMapException("Null inactivated object statement");
 		}

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivation.java
@@ -68,10 +68,10 @@ public class ORMapEventInactivation extends ORMapEvent implements
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
 			Statement typeStatement, Statement associatedKeyStmt, 
-			Statement lineage, Statement inactivatedObjectStatement) 
+			Statement lineageProgenitorStmt, Statement inactivatedObjectStatement) 
 	throws RMapException {
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt, lineage);
+				startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt, lineageProgenitorStmt);
 		if (inactivatedObjectStatement==null){
 			throw new RMapException("Null inactivated object statement");
 		}

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
@@ -77,7 +77,7 @@ public class ORMapEventTombstone extends ORMapEvent implements
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt,
-			Statement tombstoned, Statement lineage) throws RMapException {
+			Statement lineage, Statement tombstoned) throws RMapException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
 				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
@@ -77,10 +77,10 @@ public class ORMapEventTombstone extends ORMapEvent implements
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt,
-			Statement lineage, Statement tombstoned) throws RMapException {
+			Statement lineageProgenitorStmt , Statement tombstoned) throws RMapException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageProgenitorStmt);
 		this.tombstoned = tombstoned;
 	}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventTombstone.java
@@ -77,10 +77,10 @@ public class ORMapEventTombstone extends ORMapEvent implements
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt,
-			Statement tombstoned) throws RMapException {
+			Statement tombstoned, Statement lineage) throws RMapException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);
 		this.tombstoned = tombstoned;
 	}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
@@ -84,11 +84,11 @@ public class ORMapEventUpdate extends ORMapEventWithNewObjects implements RMapEv
 	public ORMapEventUpdate(Statement eventTypeStmt, Statement eventTargetTypeStmt, 
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
-			Statement typeStatement, Statement associatedKeyStmt, Statement lineageStmt, List<Statement> createdObjects,
+			Statement typeStatement, Statement associatedKeyStmt, Statement lineageProgenitorStmt, List<Statement> createdObjects,
 			Statement derivationStatement, Statement inactivatedObjectStatement) 
 	throws RMapException {
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageStmt);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageProgenitorStmt);
 		if (createdObjects==null || createdObjects.size()==0){
 			throw new RMapException ("Null or empty list of created object in Update");
 		}		

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdate.java
@@ -84,11 +84,11 @@ public class ORMapEventUpdate extends ORMapEventWithNewObjects implements RMapEv
 	public ORMapEventUpdate(Statement eventTypeStmt, Statement eventTargetTypeStmt, 
 			Statement associatedAgentStmt,  Statement descriptionStmt, 
 			Statement startTimeStmt,  Statement endTimeStmt, IRI context, 
-			Statement typeStatement, Statement associatedKeyStmt, List<Statement> createdObjects,
+			Statement typeStatement, Statement associatedKeyStmt, Statement lineageStmt, List<Statement> createdObjects,
 			Statement derivationStatement, Statement inactivatedObjectStatement) 
 	throws RMapException {
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageStmt);
 		if (createdObjects==null || createdObjects.size()==0){
 			throw new RMapException ("Null or empty list of created object in Update");
 		}		

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
@@ -77,7 +77,7 @@ public class ORMapEventUpdateWithReplace extends ORMapEvent implements RMapEvent
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt,
-			Statement updatedObjectIdStmt, Statement lineage) throws RMapException {
+			Statement lineage, Statement updatedObjectIdStmt) throws RMapException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
 				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
@@ -77,10 +77,10 @@ public class ORMapEventUpdateWithReplace extends ORMapEvent implements RMapEvent
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt,
-			Statement lineage, Statement updatedObjectIdStmt) throws RMapException {
+			Statement lineageProgenitorStmt, Statement updatedObjectIdStmt) throws RMapException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineageProgenitorStmt);
 		this.updatedObjectIdStmt = updatedObjectIdStmt;
 	}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventUpdateWithReplace.java
@@ -77,10 +77,10 @@ public class ORMapEventUpdateWithReplace extends ORMapEvent implements RMapEvent
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,  
 			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt,
-			Statement updatedObjectIdStmt) throws RMapException {
+			Statement updatedObjectIdStmt, Statement lineage) throws RMapException {
 		
 		super(eventTypeStmt,eventTargetTypeStmt,associatedAgentStmt,descriptionStmt,
-				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt);
+				startTimeStmt, endTimeStmt,context,typeStatement, associatedKeyStmt, lineage);
 		this.updatedObjectIdStmt = updatedObjectIdStmt;
 	}
 

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
@@ -68,11 +68,12 @@ public abstract class ORMapEventWithNewObjects extends ORMapEvent implements
 	protected ORMapEventWithNewObjects(Statement eventTypeStmt,
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,
-			Statement endTimeStmt, IRI context, Statement typeStatement, Statement associatedKeyStmt)
+			Statement endTimeStmt, IRI context, Statement typeStatement, 
+			Statement associatedKeyStmt, Statement lineage)
 			throws RMapException {
 		super(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,
 				descriptionStmt, startTimeStmt, endTimeStmt, context,
-				typeStatement, associatedKeyStmt);
+				typeStatement, associatedKeyStmt, lineage);
 	}
 
 	/**

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/ORMapEventWithNewObjects.java
@@ -69,11 +69,11 @@ public abstract class ORMapEventWithNewObjects extends ORMapEvent implements
 			Statement eventTargetTypeStmt, Statement associatedAgentStmt,
 			Statement descriptionStmt, Statement startTimeStmt,
 			Statement endTimeStmt, IRI context, Statement typeStatement, 
-			Statement associatedKeyStmt, Statement lineage)
+			Statement associatedKeyStmt, Statement lineageProgenitorStmt)
 			throws RMapException {
 		super(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,
 				descriptionStmt, startTimeStmt, endTimeStmt, context,
-				typeStatement, associatedKeyStmt, lineage);
+				typeStatement, associatedKeyStmt, lineageProgenitorStmt);
 	}
 
 	/**

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/OStatementsAdapter.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/OStatementsAdapter.java
@@ -288,6 +288,9 @@ public class OStatementsAdapter {
         Statement tombstonedObjectStatement = null;
         // for Delete events
         Statement deletedObjectStatement = null;
+        
+        Statement lineageStatement = null;
+        
         ORMapEvent event = null;
         for (Statement stmt:eventStmts){
             if (context==null){
@@ -356,6 +359,10 @@ public class OStatementsAdapter {
             }
             if (predicate.equals(RMAP.UPDATEDOBJECT)){
                 replacedObjectStatement=stmt;
+                continue;
+            }
+            if (predicate.equals(RMAP.LINEAGE_PROGENITOR)) {
+                lineageStatement = stmt;
                 continue;
             }
         }
@@ -430,7 +437,7 @@ public class OStatementsAdapter {
             else {
                 event = new ORMapEventCreation(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                         descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt,
-                        createdObjects);
+                        lineageStatement, createdObjects);
             }
         }
         else if (isUpdateEvent){
@@ -446,7 +453,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventUpdate(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    createdObjects,derivationStatement,inactivatedObjectStatement);
+                    lineageStatement, createdObjects,derivationStatement,inactivatedObjectStatement);
         }
         else if (isInactivateEvent){
             if (inactivatedObjectStatement==null){
@@ -454,7 +461,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventInactivation(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    inactivatedObjectStatement);
+                    inactivatedObjectStatement, lineageStatement);
         }
         else if (isDerivationEvent){
             if (sourceObjectStatement==null){
@@ -469,21 +476,23 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventDerivation(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    createdObjects,derivationStatement,sourceObjectStatement);
+                    lineageStatement, createdObjects,derivationStatement,sourceObjectStatement);
         }
         else if (isTombstoneEvent){
             if (tombstonedObjectStatement==null){
                 throw new RMapException("Tombstone event missing tombstoned object statement");
             }
             event = new ORMapEventTombstone(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
-                    descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt, tombstonedObjectStatement);
+                    descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt, 
+                    tombstonedObjectStatement, lineageStatement);
         }
         else if (isDeleteEvent){
             if (deletedObjectStatement==null){
                 throw new RMapException ("Delete event missing the deleted object statement");
             }
             event = new ORMapEventDeletion(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
-                    descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt, deletedObjectStatement);
+                    descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt, 
+                    deletedObjectStatement, lineageStatement);
         }
         else if (isReplaceEvent){
             if (replacedObjectStatement==null){
@@ -491,7 +500,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventUpdateWithReplace(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    replacedObjectStatement);
+                    replacedObjectStatement, lineageStatement);
         }
         else {
             throw new RMapException ("Unrecognized event type");

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/OStatementsAdapter.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/OStatementsAdapter.java
@@ -461,7 +461,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventInactivation(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    inactivatedObjectStatement, lineageStatement);
+                    lineageStatement, inactivatedObjectStatement);
         }
         else if (isDerivationEvent){
             if (sourceObjectStatement==null){
@@ -484,7 +484,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventTombstone(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt, 
-                    tombstonedObjectStatement, lineageStatement);
+                    lineageStatement, tombstonedObjectStatement);
         }
         else if (isDeleteEvent){
             if (deletedObjectStatement==null){
@@ -492,7 +492,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventDeletion(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt, 
-                    deletedObjectStatement, lineageStatement);
+                    lineageStatement, deletedObjectStatement);
         }
         else if (isReplaceEvent){
             if (replacedObjectStatement==null){
@@ -500,7 +500,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventUpdateWithReplace(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    replacedObjectStatement, lineageStatement);
+                    lineageStatement, replacedObjectStatement);
         }
         else {
             throw new RMapException ("Unrecognized event type");

--- a/core/src/main/java/info/rmapproject/core/model/impl/openrdf/OStatementsAdapter.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/openrdf/OStatementsAdapter.java
@@ -289,7 +289,7 @@ public class OStatementsAdapter {
         // for Delete events
         Statement deletedObjectStatement = null;
         
-        Statement lineageStatement = null;
+        Statement lineageProgenitorStatement = null;
         
         ORMapEvent event = null;
         for (Statement stmt:eventStmts){
@@ -362,7 +362,7 @@ public class OStatementsAdapter {
                 continue;
             }
             if (predicate.equals(RMAP.LINEAGE_PROGENITOR)) {
-                lineageStatement = stmt;
+                lineageProgenitorStatement = stmt;
                 continue;
             }
         }
@@ -437,7 +437,7 @@ public class OStatementsAdapter {
             else {
                 event = new ORMapEventCreation(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                         descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt,
-                        lineageStatement, createdObjects);
+                        lineageProgenitorStatement, createdObjects);
             }
         }
         else if (isUpdateEvent){
@@ -453,7 +453,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventUpdate(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    lineageStatement, createdObjects,derivationStatement,inactivatedObjectStatement);
+                    lineageProgenitorStatement, createdObjects,derivationStatement,inactivatedObjectStatement);
         }
         else if (isInactivateEvent){
             if (inactivatedObjectStatement==null){
@@ -461,7 +461,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventInactivation(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    lineageStatement, inactivatedObjectStatement);
+                    lineageProgenitorStatement, inactivatedObjectStatement);
         }
         else if (isDerivationEvent){
             if (sourceObjectStatement==null){
@@ -476,7 +476,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventDerivation(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    lineageStatement, createdObjects,derivationStatement,sourceObjectStatement);
+                    lineageProgenitorStatement, createdObjects,derivationStatement,sourceObjectStatement);
         }
         else if (isTombstoneEvent){
             if (tombstonedObjectStatement==null){
@@ -484,7 +484,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventTombstone(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt, 
-                    lineageStatement, tombstonedObjectStatement);
+                    lineageProgenitorStatement, tombstonedObjectStatement);
         }
         else if (isDeleteEvent){
             if (deletedObjectStatement==null){
@@ -492,7 +492,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventDeletion(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt,endTimeStmt, context, typeStatement, associatedKeyStmt, 
-                    lineageStatement, deletedObjectStatement);
+                    lineageProgenitorStatement, deletedObjectStatement);
         }
         else if (isReplaceEvent){
             if (replacedObjectStatement==null){
@@ -500,7 +500,7 @@ public class OStatementsAdapter {
             }
             event = new ORMapEventUpdateWithReplace(eventTypeStmt,eventTargetTypeStmt, associatedAgentStmt,
                     descriptionStmt, startTimeStmt, endTimeStmt, context, typeStatement, associatedKeyStmt,
-                    lineageStatement, replacedObjectStatement);
+                    lineageProgenitorStatement, replacedObjectStatement);
         }
         else {
             throw new RMapException ("Unrecognized event type");

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapEventMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapEventMgr.java
@@ -81,6 +81,9 @@ public class ORMapEventMgr extends ORMapObjectMgr {
 		this.createStatement(ts, event.getAssociatedAgentStmt());
 		this.createStatement(ts, event.getStartTimeStmt());
 		this.createStatement(ts, event.getEndTimeStmt());
+		if (event.getLineageProgenitorStmt() != null) {
+		    this.createStatement(ts, event.getLineageProgenitorStmt());
+		}	
 		if (event.getDescriptionStmt()!= null){
 			this.createStatement(ts, event.getDescriptionStmt());
 		}

--- a/core/src/main/java/info/rmapproject/core/utils/Terms.java
+++ b/core/src/main/java/info/rmapproject/core/utils/Terms.java
@@ -112,6 +112,9 @@ public final class Terms  {
 
  	/** The term for the tombstoned status. */
  	public static final String RMAP_TOMBSTONED = "tombstoned";
+ 	
+    /** Progenitor DiSCO as lineage ID */
+ 	public static final String RMAP_LINEAGE_PROGENITOR = "progenitor";
 
  	/*Path requests...*/
 	 /** The full path for the RMap Object class. */

--- a/core/src/main/java/info/rmapproject/core/utils/Terms.java
+++ b/core/src/main/java/info/rmapproject/core/utils/Terms.java
@@ -114,7 +114,7 @@ public final class Terms  {
  	public static final String RMAP_TOMBSTONED = "tombstoned";
  	
     /** Progenitor DiSCO as lineage ID */
- 	public static final String RMAP_LINEAGE_PROGENITOR = "progenitor";
+ 	public static final String RMAP_LINEAGE_PROGENITOR = "lineageProgenitor";
 
  	/*Path requests...*/
 	 /** The full path for the RMap Object class. */

--- a/core/src/main/java/info/rmapproject/core/vocabulary/impl/openrdf/RMAP.java
+++ b/core/src/main/java/info/rmapproject/core/vocabulary/impl/openrdf/RMAP.java
@@ -135,6 +135,9 @@ public class RMAP {
 	/** IRI for the rmap:hasStatus property*/
 	public static final IRI HASSTATUS;
 	
+	/** IRI for naming lineage via its progenitor DiSCO*/
+	public static final IRI LINEAGE_PROGENITOR;
+	
 	static {
 		final ValueFactory f = SimpleValueFactory.getInstance();
 
@@ -178,5 +181,8 @@ public class RMAP {
 		PROVIDERID = f.createIRI(NAMESPACE, Terms.RMAP_PROVIDERID);
 		IDENTITYPROVIDER = f.createIRI(NAMESPACE, Terms.RMAP_IDENTITYPROVIDER);	
 		USERAUTHID = f.createIRI(NAMESPACE, Terms.RMAP_USERAUTHID);	
+		
+		//Other properties
+		LINEAGE_PROGENITOR = f.createIRI(NAMESPACE, Terms.RMAP_LINEAGE_PROGENITOR);
 	}
 }

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapCommonEventTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapCommonEventTest.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+
+package info.rmapproject.core.model.impl.openrdf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.net.URI;
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.openrdf.model.IRI;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import info.rmapproject.core.CoreTestAbstract;
+import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.RMapLiteral;
+import info.rmapproject.core.rmapservice.impl.openrdf.ORMapEventMgr;
+import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
+
+/**
+ * Common tests for events
+ *
+ * @author apb@jhu.edu
+ */
+public abstract class ORMapCommonEventTest extends CoreTestAbstract {
+
+    @Autowired
+    private SesameTriplestore triplestore;
+
+    @Autowired
+    private ORMapEventMgr eventmgr;
+
+    @Rule
+    public final TestName name = new TestName();
+
+    RMapIri context;
+
+    final RMapIri AGENT = new RMapIri(URI.create("test:associatedAgent"));
+
+    final RMapLiteral DESCRIPTION = new RMapLiteral("my description", new RMapIri(URI.create(
+            "http://www.w3.org/2001/XMLSchema#string")));
+
+    final Date START_TIME = new Date();
+
+    final Date END_TIME = new Date();
+
+    final RMapIri ASSOCIATED_KEY = new RMapIri(URI.create("test:associatedKey"));
+
+    final RMapIri LINEAGE = new RMapIri(URI.create("test:lineage"));
+
+    /*
+     * For impls to mint events. Events should include the given values. Anything else is arbitrary.
+     */
+    protected abstract ORMapEvent newEvent(RMapIri context, RMapIri associatedAgent, RMapLiteral description,
+            Date startTime, Date endTime, RMapIri associatedKey, RMapIri lineage);
+
+    @Before
+    public void createContext() {
+        context = new RMapIri(URI.create("test:" + name.getMethodName()));
+    }
+
+    @Test
+    public void roundTripTest() {
+
+        final ORMapEvent event = roundTrip(
+                newEvent(context, AGENT, DESCRIPTION, START_TIME, END_TIME, ASSOCIATED_KEY, LINEAGE));
+
+        assertEquals(AGENT, event.getAssociatedAgent());
+        assertEquals(DESCRIPTION, event.getDescription());
+        assertEquals(ASSOCIATED_KEY, event.getAssociatedKey());
+        assertEquals(LINEAGE, event.getLineageProgenitor());
+    }
+
+    /* Yup, lineage should be nullable */
+    @Test
+    public void nullLineageTest() {
+        final ORMapEvent event = roundTrip(
+                newEvent(context, AGENT, DESCRIPTION, START_TIME, END_TIME, ASSOCIATED_KEY, null));
+
+        assertEquals(AGENT, event.getAssociatedAgent());
+        assertEquals(DESCRIPTION, event.getDescription());
+        assertEquals(ASSOCIATED_KEY, event.getAssociatedKey());
+        assertNull(event.getLineageProgenitor());
+
+        event.setLineageProgenitor(LINEAGE);
+
+        assertEquals(LINEAGE, event.getLineageProgenitor());
+    }
+
+    private ORMapEvent roundTrip(ORMapEvent initial) {
+        final IRI id = eventmgr.createEvent(initial, triplestore);
+        return eventmgr.readEvent(id, triplestore);
+    }
+}

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventCreationTest.java
@@ -29,8 +29,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -42,8 +44,8 @@ import org.openrdf.model.Statement;
 import org.openrdf.model.ValueFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import info.rmapproject.core.CoreTestAbstract;
 import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.RMapLiteral;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
 import info.rmapproject.core.model.request.RequestEventDetails;
@@ -58,7 +60,7 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  *
  */
 
-public class ORMapEventCreationTest extends CoreTestAbstract {
+public class ORMapEventCreationTest extends ORMapCommonEventTest {
 	@Autowired
 	private SesameTriplestore triplestore;
 	
@@ -130,5 +132,23 @@ public class ORMapEventCreationTest extends CoreTestAbstract {
 		
 	}
 
+
+
+    @Override
+    protected ORMapEvent newEvent(RMapIri context, RMapIri associatedAgent, RMapLiteral description, Date startTime,
+            Date endTime, RMapIri associatedKey, RMapIri lineage) {
+        
+        final ORMapEventCreation event = new ORMapEventCreation(ORAdapter.rMapIri2OpenRdfIri(context));
+        
+        event.setAssociatedAgentStatement(ORAdapter.rMapIri2OpenRdfIri(associatedAgent));
+        event.setEventTargetTypeStatement(RMapEventTargetType.DISCO);
+        event.setDescription(description);
+        event.setEndTime(endTime);
+        event.setAssociatedKeyStatement(ORAdapter.rMapIri2OpenRdfIri(associatedKey));
+        event.setLineageProgenitor(lineage);
+        event.setCreatedObjectIds(Arrays.asList(new RMapIri(URI.create("test:created"))));
+        
+        return event;
+    }
 
 }

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletionTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletionTest.java
@@ -126,7 +126,7 @@ public class ORMapEventDeletionTest extends CoreTestAbstract {
 			
 			ORMapEvent event = new ORMapEventDeletion(eventTypeStmt,eventTargetTypeStmt, 
 					associatedAgentStmt,descriptionStmt, startTimeStmt,endTimeStmt, context, 
-					typeStatement, associatedKeyStmt,  delStmt);
+					typeStatement, associatedKeyStmt,  delStmt, null);
 			Model eventModel = event.getAsModel();
 			assertEquals(9, eventModel.size());
 			IRI econtext = event.getContext();

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletionTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDeletionTest.java
@@ -27,6 +27,7 @@ import static java.net.URI.create;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -42,7 +43,6 @@ import org.openrdf.model.vocabulary.DC;
 import org.openrdf.model.vocabulary.RDF;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import info.rmapproject.core.CoreTestAbstract;
 import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.idservice.IdService;
@@ -62,7 +62,7 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  *
  */
 
-public class ORMapEventDeletionTest extends CoreTestAbstract {
+public class ORMapEventDeletionTest extends ORMapCommonEventTest {
 
 	@Autowired
 	protected IdService rmapIdService;
@@ -126,7 +126,7 @@ public class ORMapEventDeletionTest extends CoreTestAbstract {
 			
 			ORMapEvent event = new ORMapEventDeletion(eventTypeStmt,eventTargetTypeStmt, 
 					associatedAgentStmt,descriptionStmt, startTimeStmt,endTimeStmt, context, 
-					typeStatement, associatedKeyStmt,  delStmt, null);
+					typeStatement, associatedKeyStmt, null, delStmt);
 			Model eventModel = event.getAsModel();
 			assertEquals(9, eventModel.size());
 			IRI econtext = event.getContext();
@@ -180,5 +180,23 @@ public class ORMapEventDeletionTest extends CoreTestAbstract {
 			fail(e.getMessage());
 		}
 	}
+
+
+    @Override
+    protected ORMapEvent newEvent(RMapIri context, RMapIri associatedAgent, RMapLiteral description, Date startTime,
+            Date endTime, RMapIri associatedKey, RMapIri lineage) {
+        
+        final ORMapEventDeletion event = new ORMapEventDeletion(ORAdapter.rMapIri2OpenRdfIri(context));
+        
+        event.setAssociatedAgentStatement(ORAdapter.rMapIri2OpenRdfIri(associatedAgent));
+        event.setEventTargetTypeStatement(RMapEventTargetType.DISCO);
+        event.setDescription(description);
+        event.setEndTime(endTime);
+        event.setAssociatedKeyStatement(ORAdapter.rMapIri2OpenRdfIri(associatedKey));
+        event.setLineageProgenitor(lineage);
+        event.setDeletedObjectId(new RMapIri(URI.create("test:deletedObject")));
+        
+        return event;
+    }
 
 }

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivationTest.java
@@ -213,7 +213,7 @@ public class ORMapEventDerivationTest extends CoreTestAbstract {
 		Statement endTimeStmt = vf.createStatement(context, PROV.ENDEDATTIME, litEnd, context);
 		
 		ORMapEventDerivation event = new ORMapEventDerivation(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,  
-				descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt,
+				descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, null,
 				createdObjects, derivationStatement, sourceObjectStatement) ;
 		assertEquals(1,event.getCreatedObjectStatements().size());
 		assertEquals(1,event.getCreatedObjectIds().size());
@@ -229,25 +229,25 @@ public class ORMapEventDerivationTest extends CoreTestAbstract {
 		
 		try{
 			event = new ORMapEventDerivation(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,  
-					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt,
+					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, null, 
 					null, derivationStatement, sourceObjectStatement) ;
 			fail("Should not allow null created objects");
 		}catch(RMapException r){}
 		try{
 			event = new ORMapEventDerivation(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,  
-					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, 
+					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, null,
 					new ArrayList<Statement>(), derivationStatement, sourceObjectStatement) ;
 			fail("Should not allow empty created objects");
 		}catch(RMapException r){}
 		try{
 			event = new ORMapEventDerivation(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,  
-					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, 
+					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, null,
 					createdObjects, null, sourceObjectStatement) ;
 			fail("Should not allow null derived object");
 		}catch(RMapException r){}
 		try{
 			event = new ORMapEventDerivation(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,  
-					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, 
+					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, null,
 					createdObjects, derivationStatement, null) ;
 			fail("Should not allow null source object");
 		}catch(RMapException r){}		

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventDerivationTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -47,11 +48,11 @@ import org.openrdf.model.vocabulary.DC;
 import org.openrdf.model.vocabulary.RDF;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import info.rmapproject.core.CoreTestAbstract;
 import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.idservice.IdService;
 import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.RMapLiteral;
 import info.rmapproject.core.model.event.RMapEventTargetType;
 import info.rmapproject.core.model.event.RMapEventType;
 import info.rmapproject.core.model.request.RequestEventDetails;
@@ -65,7 +66,7 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  *
  */
 
-public class ORMapEventDerivationTest extends CoreTestAbstract {
+public class ORMapEventDerivationTest extends ORMapCommonEventTest {
 
 	@Autowired
 	SesameTriplestore triplestore;
@@ -253,6 +254,26 @@ public class ORMapEventDerivationTest extends CoreTestAbstract {
 		}catch(RMapException r){}		
 				
 	}
+
+
+    @Override
+    protected ORMapEvent newEvent(RMapIri context, RMapIri associatedAgent, RMapLiteral description, Date startTime,
+            Date endTime, RMapIri associatedKey, RMapIri lineage) {
+        
+        final ORMapEventDerivation event = new ORMapEventDerivation(ORAdapter.rMapIri2OpenRdfIri(context));
+        
+        event.setAssociatedAgentStatement(ORAdapter.rMapIri2OpenRdfIri(associatedAgent));
+        event.setEventTargetTypeStatement(RMapEventTargetType.DISCO);
+        event.setDescription(description);
+        event.setEndTime(endTime);
+        event.setAssociatedKeyStatement(ORAdapter.rMapIri2OpenRdfIri(associatedKey));
+        event.setLineageProgenitor(lineage);
+        event.setSourceObjectId(new RMapIri(URI.create("test:sourceObject")));
+        event.setDerivedObjectId(new RMapIri(URI.create("test:derivedObject")));
+        event.setCreatedObjectIds(Arrays.asList(new RMapIri(URI.create("test:createdObject"))));
+        
+        return event;
+    }
 
 
 }

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivationTest.java
@@ -42,7 +42,6 @@ import org.openrdf.model.vocabulary.DC;
 import org.openrdf.model.vocabulary.RDF;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import info.rmapproject.core.CoreTestAbstract;
 import info.rmapproject.core.exception.RMapDefectiveArgumentException;
 import info.rmapproject.core.exception.RMapException;
 import info.rmapproject.core.idservice.IdService;
@@ -61,7 +60,7 @@ import info.rmapproject.core.vocabulary.impl.openrdf.RMAP;
  *
  */
 
-public class ORMapEventInactivationTest extends CoreTestAbstract {
+public class ORMapEventInactivationTest extends ORMapCommonEventTest {
 
 	@Autowired	
 	SesameTriplestore triplestore;
@@ -136,7 +135,7 @@ public class ORMapEventInactivationTest extends CoreTestAbstract {
 		
 		ORMapEventInactivation event = new ORMapEventInactivation(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,  
 				descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt,
-				sourceObjectStatement, null) ;
+				null, sourceObjectStatement) ;
 		String eventTypeUrl = RMAP.INACTIVATION.toString();
 		assertEquals(eventTypeUrl, event.getEventType().getPath().toString());
 		assertEquals(RMapEventTargetType.DISCO, event.getEventTargetType());
@@ -201,5 +200,27 @@ public class ORMapEventInactivationTest extends CoreTestAbstract {
 		assertEquals(RMAP.EVENT, tStmt.getObject());
 	
 	}
+
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected ORMapEvent newEvent(RMapIri context, RMapIri associatedAgent, RMapLiteral description, Date startTime,
+            Date endTime, RMapIri associatedKey, RMapIri lineage) {
+        
+        final ORMapEventInactivation event = new ORMapEventInactivation(ORAdapter.rMapIri2OpenRdfIri(context));
+        
+        event.setAssociatedAgentStatement(ORAdapter.rMapIri2OpenRdfIri(associatedAgent));
+        event.setEventTargetTypeStatement(RMapEventTargetType.DISCO);
+        event.setDescription(description);
+        event.setEndTime(endTime);
+        event.setAssociatedKeyStatement(ORAdapter.rMapIri2OpenRdfIri(associatedKey));
+        event.setLineageProgenitor(lineage);
+        event.setInactivatedObjectId(new RMapIri(URI.create("test:inactivated")));
+        
+        return event;
+    }
 
 }

--- a/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/openrdf/ORMapEventInactivationTest.java
@@ -136,7 +136,7 @@ public class ORMapEventInactivationTest extends CoreTestAbstract {
 		
 		ORMapEventInactivation event = new ORMapEventInactivation(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,  
 				descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt,
-				sourceObjectStatement) ;
+				sourceObjectStatement, null) ;
 		String eventTypeUrl = RMAP.INACTIVATION.toString();
 		assertEquals(eventTypeUrl, event.getEventType().getPath().toString());
 		assertEquals(RMapEventTargetType.DISCO, event.getEventTargetType());
@@ -150,7 +150,7 @@ public class ORMapEventInactivationTest extends CoreTestAbstract {
 		try{
 			event = new ORMapEventInactivation(eventTypeStmt, eventTargetTypeStmt, associatedAgentStmt,  
 					descriptionStmt, startTimeStmt,  endTimeStmt, context, typeStatement, associatedKeyStmt, 
-					null) ;
+					null, null) ;
 			fail("Should not allow null source object");
 		}catch(RMapException r){}	
 	}


### PR DESCRIPTION
* Adds `RMapEvent#{set, get}LineageProgenitor(RMapIri)` for exposure of lineage in Java API
* Adds ORMap implementation of lineage progenitor via `rmap:progenitor` property`
* Tests that the (possibly null) lineage progenitor value survives round-trips to the triplestore.

Interested Parties:  @emetsger, @karenhanson

Resolves #142