### PR TITLE
Populate and expose lineage progenitor

### DIFF
--- a/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
@@ -525,4 +525,12 @@ public interface RMapService {
 	 */
 	public boolean isEventId(URI id) throws RMapException, RMapDefectiveArgumentException;
 
+	/**
+	 * Gets the lineage progenitor of the given disco
+	 *
+	 * @param discoUri URI of a DiSCO for which we want to find the lineage progenitor.
+	 * @return URI of the progenitor.
+	 */
+	public URI getLineageProgenitor(URI discoUri);
+
 }

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgr.java
@@ -25,7 +25,7 @@ package info.rmapproject.core.rmapservice.impl.openrdf;
 
 import static info.rmapproject.core.model.impl.openrdf.ORAdapter.openRdfIri2URI;
 import static info.rmapproject.core.model.impl.openrdf.ORAdapter.uri2OpenRdfIri;
-import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.findLineage;
+import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.findLineageProgenitor;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -302,7 +302,7 @@ public class ORMapDiSCOMgr extends ORMapObjectMgr {
 			if (creatorSameAsOrig){
 				ORMapEventInactivation iEvent = new ORMapEventInactivation(uri2OpenRdfIri(idSupplier.get()), reqEventDetails, RMapEventTargetType.DISCO);
 				iEvent.setInactivatedObjectId(ORAdapter.openRdfIri2RMapIri(oldDiscoId));
-				iEvent.setLineageProgenitor(new RMapIri(findLineage(openRdfIri2URI(oldDiscoId), ts)));
+				iEvent.setLineageProgenitor(new RMapIri(findLineageProgenitor(openRdfIri2URI(oldDiscoId), ts)));
 				event = iEvent;
 			}
 			else {
@@ -322,7 +322,7 @@ public class ORMapDiSCOMgr extends ORMapObjectMgr {
 			}
 			if (creatorSameAsOrig){
 				ORMapEventUpdate uEvent = new ORMapEventUpdate(uri2OpenRdfIri(idSupplier.get()), reqEventDetails, RMapEventTargetType.DISCO, oldDiscoId, disco.getDiscoContext());
-				uEvent.setLineageProgenitor(new RMapIri(findLineage(openRdfIri2URI(oldDiscoId), ts)));
+				uEvent.setLineageProgenitor(new RMapIri(findLineageProgenitor(openRdfIri2URI(oldDiscoId), ts)));
 				event = uEvent;
 			}
 			else {
@@ -414,7 +414,7 @@ public class ORMapDiSCOMgr extends ORMapObjectMgr {
 			
 		// get the event started
 		ORMapEventTombstone event = new ORMapEventTombstone(uri2OpenRdfIri(idSupplier.get()), reqEventDetails, RMapEventTargetType.DISCO, discoId);
-		event.setLineageProgenitor(new RMapIri(findLineage(openRdfIri2URI(discoId), ts)));
+		event.setLineageProgenitor(new RMapIri(findLineageProgenitor(openRdfIri2URI(discoId), ts)));
 		
 		// set up triplestore and start transaction
 		boolean doCommitTransaction = false;
@@ -475,7 +475,7 @@ public class ORMapDiSCOMgr extends ORMapObjectMgr {
 		Set<Statement> stmts = disco.getAsModel();
 		// get the event started
 		ORMapEventDeletion event = new ORMapEventDeletion(uri2OpenRdfIri(idSupplier.get()), reqEventDetails, RMapEventTargetType.DISCO, discoId);
-		event.setLineageProgenitor(new RMapIri(findLineage(openRdfIri2URI(discoId), ts)));
+		event.setLineageProgenitor(new RMapIri(findLineageProgenitor(openRdfIri2URI(discoId), ts)));
 		
 		// set up triplestore and start transaction
 		boolean doCommitTransaction = false;

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
@@ -66,22 +66,22 @@ abstract class ORMapQueriesLineage {
      * @param triplestore
      * @return URI of the progenitor, null if not present;
      */
+    @SuppressWarnings("resource")
     static URI findLineageProgenitor(URI disco, SesameTriplestore ts) {
-        try (RepositoryConnection c = ts.getConnection()) {
+        final RepositoryConnection c = ts.getConnection();
 
-            final TupleQuery q = c.prepareTupleQuery(QUERY_LINEAGE_SEARCH);
+        final TupleQuery q = c.prepareTupleQuery(QUERY_LINEAGE_SEARCH);
 
-            q.setBinding(BINDING_RESOURCE, c.getValueFactory().createIRI(disco.toString()));
+        q.setBinding(BINDING_RESOURCE, c.getValueFactory().createIRI(disco.toString()));
 
-            try (TupleQueryResult result = q.evaluate()) {
+        try (TupleQueryResult result = q.evaluate()) {
+            if (result.hasNext()) {
+                final URI found = URI.create(result.next().getBinding(BINDING_LINEAGE).getValue().toString());
                 if (result.hasNext()) {
-                    final URI found = URI.create(result.next().getBinding(BINDING_LINEAGE).getValue().toString());
-                    if (result.hasNext()) {
-                        throw new RuntimeException(String.format("Two lineages found for resource <>: <> and <>",
-                                disco, found, result.next().getBinding(BINDING_LINEAGE).toString()));
-                    }
-                    return found;
+                    throw new RuntimeException(String.format("Two lineages found for resource <>: <> and <>",
+                            disco, found, result.next().getBinding(BINDING_LINEAGE).toString()));
                 }
+                return found;
             }
         }
 

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
@@ -59,21 +59,26 @@ abstract class ORMapQueriesLineage {
                             RMAP_INACTIVATEDOBJECT_PATH) +
                     "}}";
 
-    static URI findLineage(URI object, SesameTriplestore ts) {
+    /**
+     * Find the lineage progenitor for the given disco.
+     *
+     * @param disco URI of the disco
+     * @param triplestore
+     * @return URI of the progenitor, null if not present;
+     */
+    static URI findLineageProgenitor(URI disco, SesameTriplestore ts) {
         try (RepositoryConnection c = ts.getConnection()) {
 
             final TupleQuery q = c.prepareTupleQuery(QUERY_LINEAGE_SEARCH);
 
-            q.setBinding(BINDING_RESOURCE, c.getValueFactory().createIRI(object.toString()));
-
-            System.out.println(QUERY_LINEAGE_SEARCH);
+            q.setBinding(BINDING_RESOURCE, c.getValueFactory().createIRI(disco.toString()));
 
             try (TupleQueryResult result = q.evaluate()) {
                 if (result.hasNext()) {
                     final URI found = URI.create(result.next().getBinding(BINDING_LINEAGE).getValue().toString());
                     if (result.hasNext()) {
                         throw new RuntimeException(String.format("Two lineages found for resource <>: <> and <>",
-                                object, found, result.next().getBinding(BINDING_LINEAGE).toString()));
+                                disco, found, result.next().getBinding(BINDING_LINEAGE).toString()));
                     }
                     return found;
                 }

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
@@ -21,11 +21,9 @@
 package info.rmapproject.core.rmapservice.impl.openrdf;
 
 import static info.rmapproject.core.utils.Terms.PROV_GENERATED_PATH;
-import static info.rmapproject.core.utils.Terms.RMAP_DELETEDOBJECT_PATH;
+import static info.rmapproject.core.utils.Terms.RMAP_DERIVATION_PATH;
 import static info.rmapproject.core.utils.Terms.RMAP_EVENT_PATH;
-import static info.rmapproject.core.utils.Terms.RMAP_INACTIVATEDOBJECT_PATH;
 import static info.rmapproject.core.utils.Terms.RMAP_LINEAGE_PROGENITOR_PATH;
-import static info.rmapproject.core.utils.Terms.RMAP_UPDATEDOBJECT_PATH;
 
 import java.net.URI;
 
@@ -47,16 +45,14 @@ abstract class ORMapQueriesLineage {
     static final String BINDING_RESOURCE = "resource";
 
     static final String QUERY_LINEAGE_SEARCH =
-            String.format("SELECT DISTINCT ?%s\n", BINDING_LINEAGE) +
+            String.format("SELECT ?%s\n", BINDING_LINEAGE) +
                     "WHERE {\nGRAPH ?g { \n" +
                     String.format("?e a <%s> .\n", RMAP_EVENT_PATH) +
                     String.format("?e <%s> ?%s .\n", RMAP_LINEAGE_PROGENITOR_PATH, BINDING_LINEAGE) +
                     String.format("?e ?rel ?%s .\n", BINDING_RESOURCE) +
-                    String.format("FILTER (?rel IN (<%s>, <%s>, <%s>, <%s>) )",
+                    String.format("FILTER (?rel IN (<%s>, <%s>) )",
                             PROV_GENERATED_PATH,
-                            RMAP_UPDATEDOBJECT_PATH,
-                            RMAP_DELETEDOBJECT_PATH,
-                            RMAP_INACTIVATEDOBJECT_PATH) +
+                            RMAP_DERIVATION_PATH) +
                     "}}";
 
     /**

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ */
+
+package info.rmapproject.core.rmapservice.impl.openrdf;
+
+import static info.rmapproject.core.utils.Terms.PROV_GENERATED_PATH;
+import static info.rmapproject.core.utils.Terms.RMAP_DELETEDOBJECT_PATH;
+import static info.rmapproject.core.utils.Terms.RMAP_EVENT_PATH;
+import static info.rmapproject.core.utils.Terms.RMAP_INACTIVATEDOBJECT_PATH;
+import static info.rmapproject.core.utils.Terms.RMAP_LINEAGE_PROGENITOR_PATH;
+import static info.rmapproject.core.utils.Terms.RMAP_UPDATEDOBJECT_PATH;
+
+import java.net.URI;
+
+import org.openrdf.query.TupleQuery;
+import org.openrdf.query.TupleQueryResult;
+import org.openrdf.repository.RepositoryConnection;
+
+import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
+
+/**
+ * Lineage-related sparql queries and lookups
+ *
+ * @author apb@jhu.edu
+ */
+abstract class ORMapQueriesLineage {
+
+    static final String BINDING_LINEAGE = "lineage";
+
+    static final String BINDING_RESOURCE = "resource";
+
+    static final String QUERY_LINEAGE_SEARCH =
+            String.format("SELECT DISTINCT ?%s\n", BINDING_LINEAGE) +
+                    "WHERE {\nGRAPH ?g { \n" +
+                    String.format("?e a <%s> .\n", RMAP_EVENT_PATH) +
+                    String.format("?e <%s> ?%s .\n", RMAP_LINEAGE_PROGENITOR_PATH, BINDING_LINEAGE) +
+                    String.format("?e ?rel ?%s .\n", BINDING_RESOURCE) +
+                    String.format("FILTER (?rel IN (<%s>, <%s>, <%s>, <%s>) )",
+                            PROV_GENERATED_PATH,
+                            RMAP_UPDATEDOBJECT_PATH,
+                            RMAP_DELETEDOBJECT_PATH,
+                            RMAP_INACTIVATEDOBJECT_PATH) +
+                    "}}";
+
+    static URI findLineage(URI object, SesameTriplestore ts) {
+        try (RepositoryConnection c = ts.getConnection()) {
+
+            final TupleQuery q = c.prepareTupleQuery(QUERY_LINEAGE_SEARCH);
+
+            q.setBinding(BINDING_RESOURCE, c.getValueFactory().createIRI(object.toString()));
+
+            System.out.println(QUERY_LINEAGE_SEARCH);
+
+            try (TupleQueryResult result = q.evaluate()) {
+                if (result.hasNext()) {
+                    final URI found = URI.create(result.next().getBinding(BINDING_LINEAGE).getValue().toString());
+                    if (result.hasNext()) {
+                        throw new RuntimeException(String.format("Two lineages found for resource <>: <> and <>",
+                                object, found, result.next().getBinding(BINDING_LINEAGE).toString()));
+                    }
+                    return found;
+                }
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
@@ -1153,7 +1153,11 @@ public class ORMapService implements RMapService {
 
     @Override
     public URI getLineageProgenitor(URI discoUri) {
-        return findLineageProgenitor(discoUri, triplestore);
+        try {
+            return findLineageProgenitor(discoUri, triplestore);
+        } finally {
+            closeConnection();
+        }
     }
 	
 }

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
@@ -23,6 +23,7 @@
 package info.rmapproject.core.rmapservice.impl.openrdf;
 
 import static info.rmapproject.core.model.impl.openrdf.ORAdapter.uri2OpenRdfIri;
+import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.findLineageProgenitor;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -1149,5 +1150,10 @@ public class ORMapService implements RMapService {
 			closeConnection();
 		}		
 	}
+
+    @Override
+    public URI getLineageProgenitor(URI discoUri) {
+        return findLineageProgenitor(discoUri, triplestore);
+    }
 	
 }

--- a/core/src/main/java/info/rmapproject/core/utils/Terms.java
+++ b/core/src/main/java/info/rmapproject/core/utils/Terms.java
@@ -197,6 +197,9 @@ public final class Terms  {
 
  	/** The full path for the userAuthId property of an Agent. */
  	public static final String RMAP_USERAUTHID_PATH = RMAP_NAMESPACE + RMAP_USERAUTHID;
+ 	
+ 	/** The full path for the lineageProgenitor property of an Event. */
+ 	public static final String RMAP_LINEAGE_PROGENITOR_PATH = RMAP_NAMESPACE + RMAP_LINEAGE_PROGENITOR;
 
  	
  	

--- a/core/src/test/java/info/rmapproject/core/CoreTestAbstract.java
+++ b/core/src/test/java/info/rmapproject/core/CoreTestAbstract.java
@@ -19,6 +19,9 @@
  *******************************************************************************/
 package info.rmapproject.core;
 
+import java.net.URI;
+import java.util.UUID;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -55,5 +58,7 @@ public abstract class CoreTestAbstract {
 		}
 	}
 	
-	
+    public static URI randomURI() {
+        return URI.create("urn:uuid:" + UUID.randomUUID().toString());
+    }
 }

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgrTest.java
@@ -325,17 +325,27 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
                 new RMapIri(randomURI()), 
                 Arrays.asList(randomURI()));
 
-        final ORMapDiSCO updatedDisco = new ORMapDiSCO(uri2OpenRdfIri(randomURI()), 
+        final ORMapDiSCO updatedDisco1 = new ORMapDiSCO(uri2OpenRdfIri(randomURI()), 
+                new RMapIri(randomURI()), 
+                Arrays.asList(randomURI()));
+        
+        final ORMapDiSCO updatedDisco2 = new ORMapDiSCO(uri2OpenRdfIri(randomURI()), 
                 new RMapIri(randomURI()), 
                 Arrays.asList(randomURI()));
 
         discomgr.createDiSCO(originalDisco, reqEventDetails, triplestore);
 
         discomgr.updateDiSCO(
-                rMapIri2OpenRdfIri(originalDisco.getId()), updatedDisco, reqEventDetails, false, triplestore);
+                rMapIri2OpenRdfIri(originalDisco.getId()), updatedDisco1, reqEventDetails, false, triplestore);
+        
+        discomgr.updateDiSCO(
+                rMapIri2OpenRdfIri(updatedDisco1.getId()), updatedDisco2, reqEventDetails, false, triplestore);
 
         assertEquals(findLineageProgenitor(originalDisco.getId().getIri(), triplestore),
-                findLineageProgenitor(updatedDisco.getId().getIri(), triplestore));
+                findLineageProgenitor(updatedDisco1.getId().getIri(), triplestore));
+        
+        assertEquals(findLineageProgenitor(updatedDisco1.getId().getIri(), triplestore),
+                findLineageProgenitor(updatedDisco2.getId().getIri(), triplestore));
 
     }
     

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineageTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineageTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ */
+
+package info.rmapproject.core.rmapservice.impl.openrdf;
+
+import static info.rmapproject.core.model.event.RMapEventTargetType.DISCO;
+import static info.rmapproject.core.model.impl.openrdf.ORAdapter.uri2OpenRdfIri;
+import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.findLineage;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import info.rmapproject.core.CoreTestAbstract;
+import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.impl.openrdf.ORMapEventCreation;
+import info.rmapproject.core.model.impl.openrdf.ORMapEventDerivation;
+import info.rmapproject.core.model.impl.openrdf.ORMapEventUpdate;
+import info.rmapproject.core.model.request.RequestEventDetails;
+import info.rmapproject.core.rmapservice.impl.openrdf.triplestore.SesameTriplestore;
+
+/**
+ * @author apb@jhu.edu
+ */
+public class ORMapQueriesLineageTest extends CoreTestAbstract {
+
+    @Autowired
+    private SesameTriplestore ts;
+
+    @Autowired
+    private ORMapEventMgr eventmgr;
+
+    URI discoURI;
+
+    URI lineageURI;
+
+    @Before
+    public void init() {
+        discoURI = randomURI();
+        lineageURI = randomURI();
+    }
+
+    @Test
+    public void viaCreateEventTest() {
+
+        final ORMapEventCreation event = new ORMapEventCreation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                Arrays.asList(new RMapIri(discoURI)));
+        event.setEndTime(new Date());
+        event.setLineageProgenitor(new RMapIri(lineageURI));
+
+        eventmgr.createEvent(event, ts);
+
+        assertEquals(lineageURI, findLineage(discoURI, ts));
+    }
+
+    @Test
+    public void viaUpdateEventTest() {
+
+        final URI oldDiscoUri = randomURI();
+
+        final ORMapEventUpdate event = new ORMapEventUpdate(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(oldDiscoUri),
+                uri2OpenRdfIri(discoURI));
+
+        event.setEndTime(new Date());
+        event.setLineageProgenitor(new RMapIri(lineageURI));
+
+        eventmgr.createEvent(event, ts);
+
+        // Discovering the same lineage from both the new and old discos is expected
+        assertEquals(lineageURI, findLineage(oldDiscoUri, ts));
+        assertEquals(lineageURI, findLineage(discoURI, ts));
+    }
+
+    @Test
+    public void viaDerivationTest() {
+
+        final URI oldDiscoUri = randomURI();
+
+        final ORMapEventDerivation event = new ORMapEventDerivation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(oldDiscoUri), uri2OpenRdfIri(discoURI));
+
+        event.setEndTime(new Date());
+        event.setLineageProgenitor(new RMapIri(lineageURI));
+
+        eventmgr.createEvent(event, ts);
+
+        // We shouldn't find the lineage of the thing that this event was derived from,
+        // we should only find the lineage of the newly created (derived) object
+        assertEquals(lineageURI, findLineage(discoURI, ts));
+        assertNull(findLineage(oldDiscoUri, ts));
+    }
+
+    private URI randomURI() {
+        return URI.create("urn:uuid:" + UUID.randomUUID().toString());
+    }
+
+}

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineageTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineageTest.java
@@ -22,14 +22,13 @@ package info.rmapproject.core.rmapservice.impl.openrdf;
 
 import static info.rmapproject.core.model.event.RMapEventTargetType.DISCO;
 import static info.rmapproject.core.model.impl.openrdf.ORAdapter.uri2OpenRdfIri;
-import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.findLineage;
+import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.findLineageProgenitor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -76,7 +75,7 @@ public class ORMapQueriesLineageTest extends CoreTestAbstract {
 
         eventmgr.createEvent(event, ts);
 
-        assertEquals(lineageURI, findLineage(discoURI, ts));
+        assertEquals(lineageURI, findLineageProgenitor(discoURI, ts));
     }
 
     @Test
@@ -96,8 +95,8 @@ public class ORMapQueriesLineageTest extends CoreTestAbstract {
         eventmgr.createEvent(event, ts);
 
         // Discovering the same lineage from both the new and old discos is expected
-        assertEquals(lineageURI, findLineage(oldDiscoUri, ts));
-        assertEquals(lineageURI, findLineage(discoURI, ts));
+        assertEquals(lineageURI, findLineageProgenitor(oldDiscoUri, ts));
+        assertEquals(lineageURI, findLineageProgenitor(discoURI, ts));
     }
 
     @Test
@@ -117,12 +116,7 @@ public class ORMapQueriesLineageTest extends CoreTestAbstract {
 
         // We shouldn't find the lineage of the thing that this event was derived from,
         // we should only find the lineage of the newly created (derived) object
-        assertEquals(lineageURI, findLineage(discoURI, ts));
-        assertNull(findLineage(oldDiscoUri, ts));
+        assertEquals(lineageURI, findLineageProgenitor(discoURI, ts));
+        assertNull(findLineageProgenitor(oldDiscoUri, ts));
     }
-
-    private URI randomURI() {
-        return URI.create("urn:uuid:" + UUID.randomUUID().toString());
-    }
-
 }


### PR DESCRIPTION
* Exposes Java API for finding the lineage progenitor of DiSCOs via `RMapService#getLineageProgenitor(URI discoURI)`
* Places `rmap:lineageProgenitor` property in DiSCO-related CRUD events

Interested parties: @emetsger @karenhanson 

Resolves #148 