### PR TITLE
Use lineage internally for finding versions

### DIFF
--- a/api/src/main/java/info/rmapproject/api/responsemgr/DiscoResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/DiscoResponseManager.java
@@ -200,7 +200,7 @@ public class DiscoResponseManager extends ResponseManager {
 			}
 					
 			ResourceVersions versions = 
-					new ResourceVersions(rmapService.getDiSCOAgentVersionsWithDates(uriDiscoUri));
+					new ResourceVersions(rmapService.getDiSCOVersionsWithDates(uriDiscoUri));
 
 			Date matchdate = null;
 			try {
@@ -302,7 +302,7 @@ public class DiscoResponseManager extends ResponseManager {
 			}
 
 			ResourceVersions versions = 
-					new ResourceVersions(rmapService.getDiSCOAgentVersionsWithDates(uriDiscoUri));
+					new ResourceVersions(rmapService.getDiSCOVersionsWithDates(uriDiscoUri));
 			
 			DiSCOResponseLinks discoLinks = new DiSCOResponseLinks(uriDiscoUri, status, versions);
 			Link[] links = discoLinks.getDiSCOResponseLinks();
@@ -360,7 +360,7 @@ public class DiscoResponseManager extends ResponseManager {
 			}
 							
 			ResourceVersions versions = 
-					new ResourceVersions(rmapService.getDiSCOAgentVersionsWithDates(uriDiscoUri));
+					new ResourceVersions(rmapService.getDiSCOVersionsWithDates(uriDiscoUri));
 			
 			RMapStatus discoStatus = rmapService.getDiSCOStatus(uriDiscoUri);
 			if (discoStatus==null){
@@ -774,10 +774,10 @@ public class DiscoResponseManager extends ResponseManager {
 			List <URI> uriList = null;
 			
 			if (retAgentVersionsOnly)	{
-				uriList = rmapService.getDiSCOAgentVersions(uriDiscoUri);				
+				uriList = rmapService.getDiSCOVersions(uriDiscoUri);				
 			}
 			else	{
-				uriList = rmapService.getDiSCOAllVersions(uriDiscoUri);						
+				uriList = rmapService.getDiSCODVersionsAndDerivatives(uriDiscoUri);						
 			}
 
 			if (uriList==null || uriList.size()==0)	{ 
@@ -847,7 +847,7 @@ public class DiscoResponseManager extends ResponseManager {
 				throw RMapApiException.wrap(ex, ErrorCode.ER_PARAM_WONT_CONVERT_TO_URI);
 			}
 			
-			Map<Date, URI> timemapHolder = rmapService.getDiSCOAgentVersionsWithDates(uriDiscoUri);
+			Map<Date, URI> timemapHolder = rmapService.getDiSCOVersionsWithDates(uriDiscoUri);
 			
 			if (timemapHolder==null || timemapHolder.size()==0)	{ 
 				//should always have at least one version... the one being requested!
@@ -855,7 +855,7 @@ public class DiscoResponseManager extends ResponseManager {
 			}	
 
 			ResourceVersions versions = 
-					new ResourceVersions(rmapService.getDiSCOAgentVersionsWithDates(uriDiscoUri));
+					new ResourceVersions(rmapService.getDiSCOVersionsWithDates(uriDiscoUri));
 						
 			HttpLinkBuilder links = new HttpLinkBuilder();
 			

--- a/api/src/test/java/info/rmapproject/api/responsemgr/DiscoResponseManagerTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/DiscoResponseManagerTest.java
@@ -487,7 +487,7 @@ public class DiscoResponseManagerTest extends ApiDataCreationTestAbstract {
 		String encodedDiscoUriV3 = URLEncoder.encode(discoURIV3, "UTF-8");
 		
 		//get versions list and use this to make test times
-		Map<Date, URI> versions = rmapService.getDiSCOAgentVersionsWithDates(new URI(discoURIV1));
+		Map<Date, URI> versions = rmapService.getDiSCOVersionsWithDates(new URI(discoURIV1));
 		ResourceVersions resourceVersions = new ResourceVersions(versions);
 		Date dat1 = resourceVersions.getFirstDate();
 		Calendar cal1 = Calendar.getInstance();

--- a/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
@@ -251,11 +251,10 @@ public interface RMapService {
 	public RMapEvent deleteDiSCO (URI discoID, RequestEventDetails reqEventDetails) throws RMapException, RMapDefectiveArgumentException;
 
 	/**
-	 * Get all versions of a DiSCO whether created by original creator of DiSCO or by some
-	 * other agent.
+	 * Get all versions in a DiSCO lineage, plus all DiSCOs in lineages that were derived from them
 	 *
 	 * @param discoID the DiSCO URI
-	 * @return A list of URIs for all versions of the DiSCO 
+	 * @return A list of URIs for all versions and derivative versions of the DiSCO 
 	 * @throws RMapException an RMapException
 	 * @throws RMapObjectNotFoundException an RMap object not found exception
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception

--- a/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
@@ -259,11 +259,10 @@ public interface RMapService {
 	 * @throws RMapObjectNotFoundException an RMap object not found exception
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public List<URI> getDiSCOAllVersions(URI discoID) throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException;
+	public List<URI> getDiSCODVersionsAndDerivatives(URI discoID) throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException;
 	
 	/**
-	 * Get list of versions of a DiSCO whose creating Agent is the same as the creator
-	 * of that DiSCO.
+	 * Get list of versions/revisions of a given DiSCO 
 	 *
 	 * @param discoID the DiSCO URI
 	 * @return A list of URIs for all versions of the DiSCO from the same Agent
@@ -271,11 +270,14 @@ public interface RMapService {
 	 * @throws RMapObjectNotFoundException an RMap object not found exception
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public List<URI> getDiSCOAgentVersions(URI discoID) throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException;
+	public List<URI> getDiSCOVersions(URI discoID) throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException;
 	
 	/**
-	 * Get Map of versions of a DiSCO whose creating Agent is the same as the creator of that 
-	 * DiSCO.  Map is ordered by date and contains key=date of creation (prov:endedAtTime), value=DiSCO URI
+	 * Get all versions/revisions of a given DiSCO keyed by date.  
+	 * 
+	 * <p>
+	 * Map is ordered by date and contains key=date of creation (prov:endedAtTime), value=DiSCO URI
+	 *</p>
 	 *
 	 * @param discoID the DiSCO URI
 	 * @return A list of URIs for all versions of the DiSCO from the same Agent
@@ -283,7 +285,7 @@ public interface RMapService {
 	 * @throws RMapObjectNotFoundException an RMap object not found exception
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public Map<Date,URI> getDiSCOAgentVersionsWithDates(URI discoID) throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException;
+	public Map<Date,URI> getDiSCOVersionsWithDates(URI discoID) throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException;
 	
 	/**
 	 * Gets the URI of the latest version of a DiSCO
@@ -297,7 +299,7 @@ public interface RMapService {
 	public URI getDiSCOIdLatestVersion(URI discoID) throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException;
 
 	/**
-	 * Gets the URI of the previous version of a DiSCO that was created by the same Agent
+	 * Gets the URI of the previous version of a DiSCO
 	 *
 	 * @param discoID the DiSCO URI
 	 * @return the URI of the previous version of the DiSCO
@@ -308,7 +310,7 @@ public interface RMapService {
 	public URI getDiSCOIdPreviousVersion(URI discoID) throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException;
 	
 	/**
-	 * Gets the URI of the next version of a DiSCO that was created by the same Agent
+	 * Gets the URI of the next version of a DiSCO
 	 *
 	 * @param discoID the DiSCO URI
 	 * @return the URI of the next version of a DiSCO

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgr.java
@@ -654,10 +654,10 @@ public class ORMapDiSCOMgr extends ORMapObjectMgr {
 			}
 			IRI eventId = (IRI)stmt.getSubject();
 			IRI createAgent = eventmgr.getEventAssocAgent(eventId, ts);
-			String iriSysAgent = reqEventDetails.getSystemAgent().toString();			
+			String iriSysAgent = reqEventDetails.getSystemAgent().toString();
 			isSame = (iriSysAgent.equals(createAgent.stringValue()));
-		}while (false);
-		return isSame;
-	}
+        }while (false);
+        return isSame;
+    }
 
 }

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineage.java
@@ -20,13 +20,24 @@
 
 package info.rmapproject.core.rmapservice.impl.openrdf;
 
+import static info.rmapproject.core.utils.Terms.PROV_ENDEDATTIME_PATH;
 import static info.rmapproject.core.utils.Terms.PROV_GENERATED_PATH;
-import static info.rmapproject.core.utils.Terms.RMAP_DERIVATION_PATH;
+import static info.rmapproject.core.utils.Terms.RMAP_DERIVEDOBJECT_PATH;
 import static info.rmapproject.core.utils.Terms.RMAP_EVENT_PATH;
+import static info.rmapproject.core.utils.Terms.RMAP_HASSOURCEOBJECT_PATH;
 import static info.rmapproject.core.utils.Terms.RMAP_LINEAGE_PROGENITOR_PATH;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
+import org.openrdf.model.Literal;
+import org.openrdf.query.BindingSet;
 import org.openrdf.query.TupleQuery;
 import org.openrdf.query.TupleQueryResult;
 import org.openrdf.repository.RepositoryConnection;
@@ -44,16 +55,34 @@ abstract class ORMapQueriesLineage {
 
     static final String BINDING_RESOURCE = "resource";
 
+    static final String BINDING_DATE = "date";
+
     static final String QUERY_LINEAGE_SEARCH =
             String.format("SELECT ?%s\n", BINDING_LINEAGE) +
                     "WHERE {\nGRAPH ?g { \n" +
                     String.format("?e a <%s> .\n", RMAP_EVENT_PATH) +
                     String.format("?e <%s> ?%s .\n", RMAP_LINEAGE_PROGENITOR_PATH, BINDING_LINEAGE) +
-                    String.format("?e ?rel ?%s .\n", BINDING_RESOURCE) +
-                    String.format("FILTER (?rel IN (<%s>, <%s>) )",
-                            PROV_GENERATED_PATH,
-                            RMAP_DERIVATION_PATH) +
-                    "}}";
+                    String.format("?e <%s> ?%s .\n}}", PROV_GENERATED_PATH, BINDING_RESOURCE);
+
+    static final String QUERY_GET_LINEAGE_MEMBERS =
+            String.format("SELECT ?%s ?%s\n", BINDING_RESOURCE, BINDING_DATE) +
+                    "WHERE {\nGRAPH ?g { \n" +
+                    String.format("?e a <%s> .\n", RMAP_EVENT_PATH) +
+                    String.format("?e <%s> ?%s .\n", RMAP_LINEAGE_PROGENITOR_PATH, BINDING_LINEAGE) +
+                    String.format("?e <%s> ?%s .\n", PROV_GENERATED_PATH, BINDING_RESOURCE) +
+                    String.format("?e <%s> ?%s .\n}}", PROV_ENDEDATTIME_PATH, BINDING_DATE);
+
+    static final String QUERY_FIND_DERIVATIVES =
+            String.format("SELECT ?%s\n", BINDING_RESOURCE) +
+                    "WHERE " +
+                    "{\nGRAPH ?p { \n" +
+                    String.format("?derivativeEvent a <%s> .\n", RMAP_EVENT_PATH) +
+                    String.format("?derivativeEvent <%s> ?%s .\n", RMAP_DERIVEDOBJECT_PATH, BINDING_RESOURCE) +
+                    String.format("?derivativeEvent <%s> ?lineageResource .\n", RMAP_HASSOURCEOBJECT_PATH) +
+                    "}\n GRAPH ?q {" +
+                    String.format("?eventInLineage a <%s> .\n", RMAP_EVENT_PATH) +
+                    String.format("?eventInLineage <%s> ?%s .\n", RMAP_LINEAGE_PROGENITOR_PATH, BINDING_LINEAGE) +
+                    String.format("?eventInLineage <%s> ?lineageResource .\n}}", PROV_GENERATED_PATH);
 
     /**
      * Find the lineage progenitor for the given disco.
@@ -84,4 +113,51 @@ abstract class ORMapQueriesLineage {
         return null;
     }
 
+    @SuppressWarnings("resource")
+    static Set<URI> findDerivativesfrom(URI disco, SesameTriplestore ts) {
+
+        final Set<URI> derivatives = new HashSet<>();
+        final RepositoryConnection c = ts.getConnection();
+        final TupleQuery q = c.prepareTupleQuery(QUERY_FIND_DERIVATIVES);
+
+        q.setBinding(BINDING_LINEAGE, c.getValueFactory().createIRI(disco.toString()));
+
+        try (TupleQueryResult result = q.evaluate()) {
+            while (result.hasNext()) {
+                derivatives.add(URI.create(result.next().getBinding(BINDING_RESOURCE).getValue().toString()));
+            }
+        }
+
+        return derivatives;
+    }
+
+    @SuppressWarnings("resource")
+    static Map<Date, URI> getLineageMembersWithDates(URI progenitor, SesameTriplestore ts) {
+
+        final Map<Date, URI> members = new TreeMap<>();
+
+        final RepositoryConnection c = ts.getConnection();
+        final TupleQuery q = c.prepareTupleQuery(QUERY_GET_LINEAGE_MEMBERS);
+
+        q.setBinding(BINDING_LINEAGE, c.getValueFactory().createIRI(progenitor.toString()));
+
+        try (TupleQueryResult result = q.evaluate()) {
+            while (result.hasNext()) {
+                final BindingSet val = result.next();
+
+                final Date date = new Date(((Literal) val.getValue(BINDING_DATE)).calendarValue()
+                        .toGregorianCalendar()
+                        .getTimeInMillis());
+
+                members.put(date, URI.create(val.getValue(BINDING_RESOURCE).toString()));
+            }
+        }
+
+        return members;
+    }
+
+    static List<URI> getLineageMembers(URI progenitor, SesameTriplestore ts) {
+
+        return new ArrayList<>(getLineageMembersWithDates(progenitor, ts).values());
+    }
 }

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
@@ -524,7 +524,7 @@ public class ORMapService implements RMapService {
 	
 
 	@Override
-	public List<URI> getDiSCOAllVersions(URI discoID) 
+	public List<URI> getDiSCODVersionsAndDerivatives(URI discoID) 
 	throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException {
 		if (discoID ==null){
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
@@ -546,7 +546,7 @@ public class ORMapService implements RMapService {
 	}
 	
 	@Override
-	public List<URI> getDiSCOAgentVersions(URI discoID) 
+	public List<URI> getDiSCOVersions(URI discoID) 
 	throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException {
 		if (discoID ==null){
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
@@ -559,7 +559,7 @@ public class ORMapService implements RMapService {
 	}
 	
 	@Override
-	public Map<Date,URI> getDiSCOAgentVersionsWithDates(URI discoID) 
+	public Map<Date,URI> getDiSCOVersionsWithDates(URI discoID) 
 	throws RMapException, RMapObjectNotFoundException, RMapDefectiveArgumentException {
 		if (discoID ==null){
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
@@ -578,7 +578,7 @@ public class ORMapService implements RMapService {
 			throw new RMapDefectiveArgumentException ("Null DiSCO id");
 		}
 		try {
-		    final List<URI> members = getLineageMembers(findLineageProgenitor(discoID, triplestore), triplestore);
+            final List<URI> members = getLineageMembers(findLineageProgenitor(discoID, triplestore), triplestore);
 			return members.get(members.size() - 1);
 		} finally {
 			closeConnection();

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapDiSCOMgrTest.java
@@ -511,9 +511,7 @@ public class ORMapDiSCOMgrTest extends ORMapMgrTest {
 			assertTrue(versionsForSource.contains(dUri3));
 			
 			List<URI> versionsForDerived = rmapService.getDiSCOAllVersions(dUri3);
-			assertTrue(versionsForDerived.size()==3);
-			assertTrue(versionsForDerived.contains(dUri));
-			assertTrue(versionsForDerived.contains(dUri2));
+			assertTrue(versionsForDerived.size()==1);
 			assertTrue(versionsForDerived.contains(dUri3));
 			
 		} catch (Exception e) {

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineageTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineageTest.java
@@ -211,12 +211,12 @@ public class ORMapQueriesLineageTest extends CoreTestAbstract {
         eventmgr.createEvent(update, ts);
 
         final List<URI> members = getLineageMembers(firstDiscoURI, ts);
-        // final Map<Date, URI> dates = getLineageMembersWithDates(firstDiscoURI, ts);
+        final Map<Date, URI> dates = getLineageMembersWithDates(firstDiscoURI, ts);
 
         assertTrue(members.containsAll(asList(firstDiscoURI, secondDiscoUri)));
-        // assertTrue(dates.values().containsAll(members));
-        // assertEquals(2, members.size());
-        // assertEquals(2, dates.size());
+        assertTrue(dates.values().containsAll(members));
+        assertEquals(2, members.size());
+        assertEquals(2, dates.size());
     }
 
     @Test

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineageTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapQueriesLineageTest.java
@@ -22,13 +22,21 @@ package info.rmapproject.core.rmapservice.impl.openrdf;
 
 import static info.rmapproject.core.model.event.RMapEventTargetType.DISCO;
 import static info.rmapproject.core.model.impl.openrdf.ORAdapter.uri2OpenRdfIri;
+import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.findDerivativesfrom;
 import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.findLineageProgenitor;
+import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.getLineageMembers;
+import static info.rmapproject.core.rmapservice.impl.openrdf.ORMapQueriesLineage.getLineageMembersWithDates;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +77,7 @@ public class ORMapQueriesLineageTest extends CoreTestAbstract {
         final ORMapEventCreation event = new ORMapEventCreation(
                 uri2OpenRdfIri(randomURI()),
                 new RequestEventDetails(randomURI()), DISCO,
-                Arrays.asList(new RMapIri(discoURI)));
+                asList(new RMapIri(discoURI)));
         event.setEndTime(new Date());
         event.setLineageProgenitor(new RMapIri(lineageURI));
 
@@ -86,7 +94,7 @@ public class ORMapQueriesLineageTest extends CoreTestAbstract {
         final ORMapEventCreation creation = new ORMapEventCreation(
                 uri2OpenRdfIri(randomURI()),
                 new RequestEventDetails(randomURI()), DISCO,
-                Arrays.asList(new RMapIri(oldDiscoUri)));
+                asList(new RMapIri(oldDiscoUri)));
         creation.setEndTime(new Date());
         creation.setLineageProgenitor(new RMapIri(lineageURI));
 
@@ -142,7 +150,7 @@ public class ORMapQueriesLineageTest extends CoreTestAbstract {
         final ORMapEventCreation creation = new ORMapEventCreation(
                 uri2OpenRdfIri(randomURI()),
                 new RequestEventDetails(randomURI()), DISCO,
-                Arrays.asList(new RMapIri(firstDiscoURI)));
+                asList(new RMapIri(firstDiscoURI)));
         creation.setEndTime(new Date());
         creation.setLineageProgenitor(new RMapIri(firstDiscoURI));
 
@@ -169,5 +177,159 @@ public class ORMapQueriesLineageTest extends CoreTestAbstract {
         assertNotEquals(lineageURI, findLineageProgenitor(firstDiscoURI, ts));
         assertNotEquals(lineageURI, findLineageProgenitor(secondDiscoUri, ts));
         assertEquals(findLineageProgenitor(firstDiscoURI, ts), findLineageProgenitor(secondDiscoUri, ts));
+    }
+
+    @Test
+    public void lineageMembersStartwithCreationTest() {
+        final URI firstDiscoURI = randomURI();
+        final URI secondDiscoUri = randomURI();
+
+        final ORMapEventCreation creation = new ORMapEventCreation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                asList(new RMapIri(firstDiscoURI)));
+        creation.setEndTime(new Date(0));
+        creation.setLineageProgenitor(new RMapIri(firstDiscoURI));
+
+        final ORMapEventUpdate update = new ORMapEventUpdate(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(firstDiscoURI),
+                uri2OpenRdfIri(secondDiscoUri));
+        update.setEndTime(new Date(1));
+        update.setLineageProgenitor(new RMapIri(firstDiscoURI));
+
+        final ORMapEventDerivation derivation = new ORMapEventDerivation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(secondDiscoUri), uri2OpenRdfIri(discoURI));
+        derivation.setEndTime(new Date(2));
+        derivation.setLineageProgenitor(new RMapIri(lineageURI));
+
+        eventmgr.createEvent(creation, ts);
+        eventmgr.createEvent(derivation, ts);
+        eventmgr.createEvent(update, ts);
+
+        final List<URI> members = getLineageMembers(firstDiscoURI, ts);
+        // final Map<Date, URI> dates = getLineageMembersWithDates(firstDiscoURI, ts);
+
+        assertTrue(members.containsAll(asList(firstDiscoURI, secondDiscoUri)));
+        // assertTrue(dates.values().containsAll(members));
+        // assertEquals(2, members.size());
+        // assertEquals(2, dates.size());
+    }
+
+    @Test
+    public void lineageMembersStartwithDerivationTest() {
+        final URI firstDiscoURI = randomURI();
+        final URI secondDiscoUri = randomURI();
+
+        final ORMapEventDerivation creation = new ORMapEventDerivation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(randomURI()), uri2OpenRdfIri(firstDiscoURI));
+        creation.setEndTime(new Date(0));
+        creation.setLineageProgenitor(new RMapIri(firstDiscoURI));
+
+        final ORMapEventUpdate update = new ORMapEventUpdate(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(firstDiscoURI),
+                uri2OpenRdfIri(secondDiscoUri));
+        update.setEndTime(new Date(1));
+        update.setLineageProgenitor(new RMapIri(firstDiscoURI));
+
+        final ORMapEventDerivation derivation = new ORMapEventDerivation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(secondDiscoUri), uri2OpenRdfIri(discoURI));
+        derivation.setEndTime(new Date(2));
+        derivation.setLineageProgenitor(new RMapIri(lineageURI));
+
+        eventmgr.createEvent(creation, ts);
+        eventmgr.createEvent(derivation, ts);
+        eventmgr.createEvent(update, ts);
+
+        final List<URI> members = getLineageMembers(firstDiscoURI, ts);
+        final Map<Date, URI> dates = getLineageMembersWithDates(firstDiscoURI, ts);
+
+        assertTrue(members.containsAll(asList(firstDiscoURI, secondDiscoUri)));
+        assertTrue(dates.values().containsAll(members));
+        assertEquals(2, members.size());
+        assertEquals(2, dates.size());
+    }
+
+    @Test
+    public void findDerivativesTest() {
+
+        // Lineage members
+        final URI l1 = randomURI();
+        final URI l2 = randomURI();
+        final URI l3 = randomURI();
+
+        // Derivatives
+        final URI d1 = randomURI();
+        final URI d3 = randomURI();
+
+        // Derivative of derivative 1
+        final URI dd1 = randomURI();
+
+        // Now the initial lineage chain
+        // Start with a derivative, since that's the most challenging
+        final ORMapEventDerivation l1c = new ORMapEventDerivation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(randomURI()), uri2OpenRdfIri(l1));
+        l1c.setEndTime(new Date(0));
+        l1c.setLineageProgenitor(new RMapIri(l1));
+
+        final ORMapEventUpdate l2u = new ORMapEventUpdate(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(l1),
+                uri2OpenRdfIri(l2));
+        l2u.setEndTime(new Date(1));
+        l2u.setLineageProgenitor(new RMapIri(l1));
+
+        final ORMapEventUpdate l3u = new ORMapEventUpdate(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(l2),
+                uri2OpenRdfIri(l3));
+        l3u.setEndTime(new Date(2));
+        l3u.setLineageProgenitor(new RMapIri(l1));
+
+        // Now create derivatives
+
+        // ... of l1
+        final ORMapEventDerivation l1d = new ORMapEventDerivation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(l1), uri2OpenRdfIri(d1));
+        l1d.setEndTime(new Date(3));
+        l1d.setLineageProgenitor(new RMapIri(randomURI()));
+
+        // ... of l2
+        final ORMapEventDerivation l3d = new ORMapEventDerivation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(l3), uri2OpenRdfIri(d3));
+        l3d.setEndTime(new Date(4));
+        l3d.setLineageProgenitor(new RMapIri(randomURI()));
+
+        // ... of the derivative of l1 (a derivative of a derivative)
+        final ORMapEventDerivation l1dd = new ORMapEventDerivation(
+                uri2OpenRdfIri(randomURI()),
+                new RequestEventDetails(randomURI()), DISCO,
+                uri2OpenRdfIri(dd1), uri2OpenRdfIri(randomURI()));
+        l1dd.setEndTime(new Date(5));
+        l1dd.setLineageProgenitor(new RMapIri(randomURI()));
+
+        asList(l1c, l2u, l3u, l1d, l3d, l1dd).forEach(e -> eventmgr.createEvent(e, ts));
+
+        final Set<URI> derivatives = findDerivativesfrom(l1, ts);
+        assertEquals(2, derivatives.size());
+        assertTrue(derivatives.containsAll(asList(d1, d3)));
+
     }
 }

--- a/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
@@ -155,8 +155,8 @@ public class DataDisplayServiceImpl implements DataDisplayService {
 		discoDTO.setProvGeneratedBy(disco.getProvGeneratedBy());
 		discoDTO.setProviderId(disco.getProviderId());
 		
-		discoDTO.setAgentVersions(rmapService.getDiSCOAgentVersions(discoUri));
-		discoDTO.setAllVersions(rmapService.getDiSCOAllVersions(discoUri));
+		discoDTO.setAgentVersions(rmapService.getDiSCOVersions(discoUri));
+		discoDTO.setAllVersions(rmapService.getDiSCODVersionsAndDerivatives(discoUri));
 		
 		discoDTO.setStatus(rmapService.getDiSCOStatus(discoUri));
 		discoDTO.setEvents(rmapService.getDiSCOEvents(discoUri));


### PR DESCRIPTION
* Clarifies and renames methods for finding versions and derivatives of discos in `RMapService`
* Uses event lineage sparql queries for finding versions and derives, rather than event crawling

Resolves #143