### PR TITLE
Add lazy=false to db model objects

### DIFF
--- a/auth/src/main/java/info/rmapproject/auth/model/ApiKey.java
+++ b/auth/src/main/java/info/rmapproject/auth/model/ApiKey.java
@@ -29,6 +29,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Proxy;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -42,6 +43,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
 @Table(name="ApiKeys")
+@Proxy(lazy=false)
 public class ApiKey {
 	
 	/** Unique id column for API Key table*. */

--- a/auth/src/main/java/info/rmapproject/auth/model/User.java
+++ b/auth/src/main/java/info/rmapproject/auth/model/User.java
@@ -33,6 +33,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Proxy;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -45,6 +46,7 @@ import org.hibernate.validator.constraints.NotEmpty;
  */
 @Entity
 @Table(name="Users")
+@Proxy(lazy=false)
 public class User {
 	
 	/** Primary key for Users database, incrementing integer. */

--- a/auth/src/main/java/info/rmapproject/auth/model/UserIdentityProvider.java
+++ b/auth/src/main/java/info/rmapproject/auth/model/UserIdentityProvider.java
@@ -27,6 +27,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Proxy;
+
 /**
  * Java representation of UserIdentityProviders database table.
  * Stores details of ID provider accounts for User
@@ -36,6 +38,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name="UserIdentityProviders")
+@Proxy(lazy=false)
 public class UserIdentityProvider {
 	
 	/** Primary key for UserIdentityProviders table, incrementing integer. */

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/ApiKeyController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/ApiKeyController.java
@@ -159,7 +159,7 @@ public class ApiKeyController {
 	/**
 	 * Receives the POSTed Edit API Key form to be processed. Returns any form errors.
 	 *
-	 * @param apiKey the API Key object
+	 * @param apiKeyForm the API Key object
 	 * @param result the form result
 	 * @param model the Spring model
 	 * @return the user key page
@@ -167,14 +167,16 @@ public class ApiKeyController {
 	 */
 	@LoginRequired
 	@RequestMapping(value={"/user/key/edit","/admin/user/key/edit"}, method=RequestMethod.POST)
-	public String updateUserKey(@Valid ApiKey apiKey, BindingResult result, ModelMap model, HttpSession session, RedirectAttributes redirectAttributes) throws Exception {
+	public String updateUserKey(@Valid ApiKey apiKeyForm, BindingResult result, ModelMap model, HttpSession session, RedirectAttributes redirectAttributes) throws Exception {
 		User user = (User) session.getAttribute("user"); //retrieve logged in user
-        if (result.hasErrors() || user.getUserId()!=apiKey.getUserId()) {
+        //refresh key from db - form bound key does not include userId but we should check session user id matches key user id
+		ApiKey origApiKey = userMgtService.getApiKeyById(apiKeyForm.getApiKeyId());
+		if (result.hasErrors() || user.getUserId()!=origApiKey.getUserId()) {
 			model.addAttribute("targetPage", "keyedit");
     		model.addAttribute("notice", "Errors found, key could not be saved.");	
             return "user/key";
         }
-		this.userMgtService.updateApiKey(apiKey);	
+		this.userMgtService.updateApiKey(apiKeyForm);	
 		redirectAttributes.addFlashAttribute("notice", "Key settings have been saved.");	
 		Boolean isAdmin = (Boolean) session.getAttribute(Constants.ADMIN_LOGGEDIN_SESSATTRIB);
 		if (isAdmin!=null && isAdmin) {

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/SitePropertiesToModelInterceptor.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/SitePropertiesToModelInterceptor.java
@@ -77,7 +77,9 @@ public class SitePropertiesToModelInterceptor implements HandlerInterceptor {
 	 */
 	@Override
 	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
-		modelAndView.addObject(SITE_PROPERTIES_ATTRIBNAME, this.siteProperties);
+		if (modelAndView!=null){
+			modelAndView.addObject(SITE_PROPERTIES_ATTRIBNAME, this.siteProperties);
+		}
 	}
 
 }

--- a/webapp/src/test/java/info/rmapproject/webapp/controllers/ApiKeyControllerTest.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/controllers/ApiKeyControllerTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a 
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.webapp.controllers;
+
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import info.rmapproject.auth.model.User;
+import info.rmapproject.webapp.WebDataRetrievalTestAbstract;
+import info.rmapproject.webapp.service.UserMgtService;
+import info.rmapproject.webapp.utils.Constants;
+
+/**
+ * Basic tests for HomeController, which returns views for home and contact page.
+ * @author khanson
+ *
+ */
+@TestPropertySource(properties = {
+		"rmapauth.baseUrl=https://fake-rmap-server.org",
+		"rmapcore.adminAgentUri=https://fake-rmap-server.org#Administrator",
+		"rmapweb.admin-tool-enabled=true",
+		"rmapweb.admin-username=rmapAdmin",
+		"rmapweb.admin-password=somepass"
+		})
+public class ApiKeyControllerTest extends WebDataRetrievalTestAbstract {
+
+	
+	@Autowired
+	private UserMgtService userMgtService;
+	
+	@Autowired
+	private WebApplicationContext wac;
+	
+	private MockMvc mockMvc;
+	
+	@Before
+	public void init() {
+	    mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+	}
+	
+	/**
+	 * Tests api key download
+	 * @throws Exception
+	 */
+	@Test
+	public void downloadKeyTest() throws Exception {
+		User user = userMgtService.getUserById(1);
+		MvcResult result = 
+		        mockMvc.perform(get("/admin/user/key/download").sessionAttr(Constants.ADMIN_LOGGEDIN_SESSATTRIB, true).sessionAttr("user", user).param("keyid", "1"))
+		        .andReturn();
+	    
+	    String content = result.getResponse().getContentAsString();
+	    String keyPass=":";
+	    assertTrue(content.contains(keyPass));
+	}
+    
+}

--- a/webapp/src/test/java/info/rmapproject/webapp/controllers/ApiKeyControllerTest.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/controllers/ApiKeyControllerTest.java
@@ -37,7 +37,7 @@ import info.rmapproject.webapp.service.UserMgtService;
 import info.rmapproject.webapp.utils.Constants;
 
 /**
- * Basic tests for HomeController, which returns views for home and contact page.
+ * Basic tests for ApiKeyController, which handles API Key management pages in RMap GUI.
  * @author khanson
  *
  */


### PR DESCRIPTION
Investigated this after noticing that when using in-memory derby, an error occurs on the key download page saying can't lazy load the data. It does not occur on live tests.  To resolve this, made the following changes:

- Force lazy=false on the database model. My best guess at what is happening is that different connections configurations have different default behavior wrt ending session on commit. In particular, it seems the in-memory derbydb ends the session on commit which causes anything that has lazy load not to load when retrieved after commit e.g. ApiKey.getUserId(). This happens in the ApiKeyController.downloadKey() method.  We can either disable session close on commit for each
connection, or just force lazy=false by adding an annotation to the data model classes - this makes it OK to close session when you're done with the database.  Rather than have to keep dealing with different behaviors via Spring config, I opted to add lazy=false since the data model is small and any eager load will not have to load much data, even where there are joins.
- Added a test to ensure downloadKey now working
- Added a null check on site properties
- Fixed bug to do with validation of session userId against key userId in the key edit form.