### PR TITLE
Corrected method name for RMapService.getResourceRdfTypesInDiSCO

### DIFF
--- a/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/RMapService.java
@@ -116,12 +116,12 @@ public interface RMapService {
 	 * Determine what types are associated with a given resource within a specific DiSCO
 	 *
 	 * @param resourceUri URI for resource whose type is being checked
-	 * @param discoUri the URI of the DiSCO
+	 * @param contextUri the URI of the DiSCO, Event, or Agent to filter types by
 	 * @return Set of URIs indicating resource type(s)
 	 * @throws RMapException an RMapException
 	 * @throws RMapDefectiveArgumentException an RMap defective argument exception
 	 */
-	public List<URI> getResourceRdfTypesInDiSCO(URI resourceUri, URI discoUri) throws RMapException, RMapDefectiveArgumentException;
+	public List<URI> getResourceRdfTypesInContext(URI resourceUri, URI contextUri) throws RMapException, RMapDefectiveArgumentException;
 	
 	/**
 	 * Determine what types are associated with a given resource in any DiSCO.

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/openrdf/ORMapService.java
@@ -261,19 +261,19 @@ public class ORMapService implements RMapService {
 	}
 	
 	/* (non-Javadoc)
-	 * @see info.rmapproject.core.rmapservice.RMapService#getResourceRdfTypes(java.net.URI, java.net.URI)
+	 * @see info.rmapproject.core.rmapservice.RMapService#getResourceRdfTypesInContext(java.net.URI, java.net.URI)
 	 */
 	@Override
-	public List<URI> getResourceRdfTypesInDiSCO(URI resourceUri, URI discoUri)
+	public List<URI> getResourceRdfTypesInContext(URI resourceUri, URI contextUri)
 			throws RMapException, RMapDefectiveArgumentException {
 		if (resourceUri==null){
 			throw new RMapDefectiveArgumentException("Null resource URI");
 		}
-		if (discoUri==null){
-			throw new RMapDefectiveArgumentException("Null context URI");
+		if (contextUri==null){
+			throw new RMapDefectiveArgumentException("Null RMap Object URI");
 		}
 		org.openrdf.model.IRI resourceIri = uri2OpenRdfIri(resourceUri);
-		org.openrdf.model.IRI contextIri = uri2OpenRdfIri(discoUri);
+		org.openrdf.model.IRI contextIri = uri2OpenRdfIri(contextUri);
 
 		try {
 			List<org.openrdf.model.IRI> uris = resourcemgr.getResourceRdfTypes(resourceIri, contextIri, triplestore);

--- a/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
@@ -698,7 +698,7 @@ public class DataDisplayServiceImpl implements DataDisplayService {
 		if (contextUri==null){
 			return getResourceRDFTypes(resourceUri);
 		}
-		List<URI> rdfTypes = rmapService.getResourceRdfTypesInDiSCO(resourceUri, contextUri);
+		List<URI> rdfTypes = rmapService.getResourceRdfTypesInContext(resourceUri, contextUri);
 
 		return rdfTypes;
 	}	

--- a/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
@@ -179,7 +179,7 @@ public class DataDisplayServiceImpl implements DataDisplayService {
 		}
 		
 		if (WebappUtils.isUri(discoDTO.getProviderId())) {
-			List<URI> rdfTypes = rmapService.getResourceRdfTypesInDiSCO(new URI(discoDTO.getProviderId()), discoDTO.getUri());
+			List<URI> rdfTypes = rmapService.getResourceRdfTypesInContext(new URI(discoDTO.getProviderId()), discoDTO.getUri());
 			String targetNodeType = WebappUtils.getNodeType(rdfTypes);
 			graph.addEdge(sDiscoUri, discoDTO.getProviderId(), RMAP.PROVIDERID.toString(), discoNodeType, targetNodeType);
 		}
@@ -187,7 +187,7 @@ public class DataDisplayServiceImpl implements DataDisplayService {
 		params.setStatusCode(RMapStatusFilter.ACTIVE);
 		
 		for (URI aggregate : discoDTO.getAggregatedResources()) {
-			List<URI> rdfTypes = rmapService.getResourceRdfTypesInDiSCO(aggregate, discoDTO.getUri());
+			List<URI> rdfTypes = rmapService.getResourceRdfTypesInContext(aggregate, discoDTO.getUri());
 			String targetNodeType = WebappUtils.getNodeType(rdfTypes);
 			graph.addEdge(sDiscoUri, aggregate.toString(),Terms.ORE_AGGREGATES_PATH, discoNodeType, targetNodeType);
 		}


### PR DESCRIPTION
The method works for any graph so getResourceRdfTypesInContext is more accurate.