### PR TITLE
Make date formatting and picker code more generic

### DIFF
--- a/auth/src/main/java/info/rmapproject/auth/model/ApiKey.java
+++ b/auth/src/main/java/info/rmapproject/auth/model/ApiKey.java
@@ -75,11 +75,11 @@ public class ApiKey {
 	private KeyStatus keyStatus;
 	
 	/**The start date from which the key is valid. If the key is used before this date it will not work */
-	@DateTimeFormat(pattern = "MM/dd/yyyy")
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private Date startDate;
 	
 	/**The end date for the key after which the key is no longer valid.  If the key is used after this date it will not work*/
-	@DateTimeFormat(pattern = "MM/dd/yyyy")
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private Date endDate;
 	
 	/** The date the key was created*. */

--- a/core/src/main/java/info/rmapproject/core/utils/DateUtils.java
+++ b/core/src/main/java/info/rmapproject/core/utils/DateUtils.java
@@ -43,6 +43,20 @@ public class DateUtils {
 	private DateUtils() {}
 	
 	/**
+	 * Gets date from string according to format provided.
+	 * @param dateString
+	 * @param format e.g. "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "yyyy-MM-dd"
+	 * @return
+	 */
+	public static Date getDateFromString(String dateString, String format)
+	throws ParseException{
+		Date finalResult = null;
+		DateFormat dateformat = new SimpleDateFormat(format);
+		finalResult = dateformat.parse(dateString);		
+		return finalResult;
+	}
+	
+	/**
 	 * Parse ISO 8601 date string into Date object.
 	 *
 	 * @param dateString String containing ISO8601 formatted date
@@ -51,10 +65,7 @@ public class DateUtils {
 	 */
 	public static Date getDateFromIsoString(String dateString) 
 	throws ParseException{
-		Date finalResult = null;
-		DateFormat format = new SimpleDateFormat(ISO8601);
-		finalResult = format.parse(dateString);		
-		return finalResult;
+		return getDateFromString(dateString, ISO8601);
 	}
 	
 	/**
@@ -84,4 +95,26 @@ public class DateUtils {
         }
         return calendar.toGregorianCalendar().getTime();
     }
+    
+	/**
+	 * If date is valid according to format provided, returns true. Otherwise returns false.
+	 * @param sDate
+	 * @param format
+	 * @return
+	 */
+	public static boolean isValidDate(String sDate, String format) {
+		if(sDate == null){
+			return false;
+		}
+		SimpleDateFormat sdf = new SimpleDateFormat(format);
+		sdf.setLenient(false);
+		try {
+			//if not valid, it will throw ParseException
+			sdf.parse(sDate);
+		} catch (Exception e) {
+			return false;
+		}
+		return true;
+	}	
+    
 }

--- a/webapp/src/main/webapp/WEB-INF/tags/pageStartStandard.tag
+++ b/webapp/src/main/webapp/WEB-INF/tags/pageStartStandard.tag
@@ -8,24 +8,22 @@
 <c:set var="incCal" value="${(empty includeCalendarScripts) ? false : includeCalendarScripts}" />
 
 <tl:headerDocType/>
-<head>
+<head>        
 	<tl:headRequiredContent pageTitle="${pageTitle}" />
 	
 	<c:if test="${incCal}" >
 		<link href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/> 
 		<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8/jquery-ui.min.js"></script> 
-		<script>
-			$(document).ready(function() {
-				$("#startDate").datepicker();
+		<script>		
+			$( function() {
+				$(".formDate").datepicker({
+					dateFormat: "yy-mm-dd"
 				});
-				
-			$(document).ready(function() {
-				$("#endDate").datepicker();
+				$(".clearFormDate").click(function(){
+					var fld = $(this).data("field");
+					document.getElementById(fld).value="";
 				});
-			
-			function clearfield (fieldname){
-				document.getElementById(fieldname).value ='';
-			}
+			});
 		</script>
 	</c:if>
 </head>

--- a/webapp/src/main/webapp/WEB-INF/views/user/key.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/user/key.jsp
@@ -36,19 +36,17 @@
 			<form:label path="keyStatus">Status</form:label> 
 			<form:errors path="keyStatus" cssClass="validationErrors"/>
 			<form:select path="keyStatus" multiple="false">
-				<form:option value="" label="-----Select-----"/>
 				<form:options values="${keyStatuses}" items="${keyStatuses}"/>
 			</form:select>			
 			
 			<form:label path="startDate">Start date (leave blank for no fixed start date)</form:label> 
 			<form:errors path="startDate" cssClass="validationErrors"/>
-			<form:input path="startDate" cssClass="dateInput" readonly="true" style="float:left;"/>
-			&nbsp;<img src="<c:url value='/includes/images/delete.png'/>" onclick="clearfield('startDate')" style="padding-top:8px;">
-			<br/>
+			<form:input path="startDate" placeholder="yyyy-mm-dd" cssClass="dateInput formDate" readonly="true"/>
+			&nbsp;<div class="clearFormDate clickableText rightOfInput" data-field="startDate">clear</div>
 			<form:label path="endDate">End date (leave blank for no fixed end date)</form:label> 
 			<form:errors path="endDate" cssClass="validationErrors"/>
-			<form:input path="endDate" cssClass="dateInput" readonly="true" style="float:left;"/>
-			&nbsp;<img src="<c:url value='/includes/images/delete.png'/>" onclick="clearfield('endDate')" style="padding-top:8px;">
+			<form:input path="endDate" placeholder="yyyy-mm-dd" cssClass="dateInput formDate" readonly="true"/>
+			&nbsp;<div class="clearFormDate clickableText rightOfInput" data-field="endDate">clear</div>
 					
 			<form:label path="includeInEvent">Include Key URI in RMap Event?</form:label>
 			<form:radiobutton path="includeInEvent" value="yes"/> Yes <br/>

--- a/webapp/src/main/webapp/includes/stylesheets/layout.css
+++ b/webapp/src/main/webapp/includes/stylesheets/layout.css
@@ -389,7 +389,7 @@ select {padding: 5px; border: 1px solid #ccc; margin: 5px 0; width:507px;}
 input[type=text] {padding: 5px; width:500px;border: 1px solid #ccc; margin: 5px 0;}
 input[type=checkbox] {padding-left:2px;}
 textarea {width:500px;padding: 5px; margin: 5px 0; resize: vertical;}
-input[type=text].dateInput {width:200px; }
+input[type=text].dateInput {width:100px; display:inline-block;}
 input[readonly]{background-color:#f0f0f0;}
 
 #truncate {
@@ -450,6 +450,8 @@ input[readonly]{background-color:#f0f0f0;}
 	font-style:italic;
 	float:left;
 	margin-top:5px;
+	overflow-wrap: break-word; 
+	word-wrap: break-word;
 }
 
 .sidebarPageCounter {
@@ -606,3 +608,7 @@ input[readonly]{background-color:#f0f0f0;}
     border-color: transparent transparent #6f6f6f transparent;
 }
 
+.rightOfInput {
+	 display:inline-block;
+	 margin-top:3px;
+}


### PR DESCRIPTION
- generalized date picker code for use with other date fields
- added css to support clear button to right of date picker
- made all dates format to yyyy-mm-dd to avoid day/month mix up and show this as a placeholder in input fields
- modified date range validation methods for yyyy-mm-dd - can now use this format through API as date filter.
- applied these modifications to datepicker on key form
- set ACTIVE as default key status in key form