### PR TITLE
Add default message for RMap API root path

### DIFF
--- a/api/src/main/java/info/rmapproject/api/responsemgr/AgentResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/AgentResponseManager.java
@@ -86,7 +86,7 @@ public class AgentResponseManager extends ResponseManager {
 		Response response = null;
 		try {				
 			response = Response.status(Response.Status.OK)
-						.entity("{\"description\":\"Follow header link to read documentation.\"}")
+						.entity("{\"description\":\"" + pathUtils.getDocumentationPath() + "\"}")
 						.allow(HttpMethod.HEAD, HttpMethod.OPTIONS, HttpMethod.GET)
 						.link(pathUtils.getDocumentationPath(),LinkRels.DC_DESCRIPTION)
 						.build();

--- a/api/src/main/java/info/rmapproject/api/responsemgr/DiscoResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/DiscoResponseManager.java
@@ -127,7 +127,7 @@ public class DiscoResponseManager extends ResponseManager {
 		Response response = null;
 		try {				
 			response = Response.status(Response.Status.OK)
-					.entity("{\"description\":\"Follow header link to read documentation.\"}")
+					.entity("{\"description\":\"" + pathUtils.getDocumentationPath() + "\"}")
 					.allow(HttpMethod.HEAD, HttpMethod.OPTIONS,HttpMethod.GET,HttpMethod.POST,HttpMethod.DELETE)
 					.link(pathUtils.getDocumentationPath(),LinkRels.DC_DESCRIPTION)
 					.build();

--- a/api/src/main/java/info/rmapproject/api/responsemgr/EventResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/EventResponseManager.java
@@ -78,7 +78,7 @@ public class EventResponseManager extends ResponseManager {
 		Response response = null;
 		try {				
 			response = Response.status(Response.Status.OK)
-					.entity("{\"description\":\"Follow header link to read documentation.\"}")
+					.entity("{\"description\":\"" + pathUtils.getDocumentationPath() + "\"}")
 					.allow(HttpMethod.HEAD,HttpMethod.OPTIONS,HttpMethod.GET)
 					.link(pathUtils.getDocumentationPath(),LinkRels.DC_DESCRIPTION)
 					.build();

--- a/api/src/main/java/info/rmapproject/api/responsemgr/ResourceResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/ResourceResponseManager.java
@@ -80,7 +80,7 @@ public class ResourceResponseManager extends ResponseManager {
 		Response response = null;
 		try {				
 			response = Response.status(Response.Status.OK)
-					.entity("{\"description\":\"Follow header link to read documentation.\"}")
+					.entity("{\"description\":\"" + pathUtils.getDocumentationPath() + "\"}")
 					.allow(HttpMethod.HEAD,HttpMethod.OPTIONS,HttpMethod.GET)
 					.link(pathUtils.getDocumentationPath(),LinkRels.DC_DESCRIPTION)	
 					.build();

--- a/api/src/main/java/info/rmapproject/api/responsemgr/StatementResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/StatementResponseManager.java
@@ -81,7 +81,7 @@ public class StatementResponseManager extends ResponseManager {
 		Response response = null;
 		try {			
 			response = Response.status(Response.Status.OK)
-					.entity("{\"description\":\"Follow header link to read documentation.\"}")
+					.entity("{\"description\":\"" + pathUtils.getDocumentationPath() + "\"}")
 					.allow(HttpMethod.HEAD,HttpMethod.OPTIONS,HttpMethod.GET)
 					.link(pathUtils.getDocumentationPath(),LinkRels.DC_DESCRIPTION)	
 					.build();

--- a/api/src/main/java/info/rmapproject/api/service/AgentApiService.java
+++ b/api/src/main/java/info/rmapproject/api/service/AgentApiService.java
@@ -71,7 +71,7 @@ public class AgentApiService {
 	}
 
 	/**
-	 * HEAD /agent
+	 * HEAD /agents
 	 * Returns Agent API information/link, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -82,10 +82,23 @@ public class AgentApiService {
     	Response response = getAgentResponseManager().getAgentServiceHead();
 	    return response;
     }
-    
 
 	/**
-	 * OPTIONS /agent
+	* GET /agents
+	* Returns link to Agent API information, and lists HTTP options.
+	*
+	* @return HTTP Response
+	* @throws RMapApiException the RMap API exception
+	*/
+    @GET
+    public Response getServiceInfo() throws RMapApiException {
+    	//TODO: for now returns same as options, but might want html response to describe API?
+    	Response response = getAgentResponseManager().getAgentServiceOptions();
+	    return response;
+    }
+
+	/**
+	 * OPTIONS /agents
 	 * Returns Agent API information/link, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -93,7 +106,7 @@ public class AgentApiService {
 	 */
     @OPTIONS
     public Response apiGetApiDetailedOptions() throws RMapApiException {
-    	Response response = getAgentResponseManager().getAgentServiceHead();
+    	Response response = getAgentResponseManager().getAgentServiceOptions();
 	    return response;
     }
     
@@ -108,7 +121,7 @@ public class AgentApiService {
  */
     
 	/**
- * GET /agent/{agentUri}
+ * GET /agents/{agentUri}
  * Returns requested RMap:Agent as RDF/XML, JSON-LD, Turtle or NQUADS.
  *
  * @param headers the HTTP request headers
@@ -137,7 +150,7 @@ public class AgentApiService {
  *-------------------------------
  */
  /**
- * HEAD /agent/{agentUri}
+ * HEAD /agents/{agentUri}
  * Returns status information for specific Agent as a HTTP response header. 
  * Includes event list, versions, and URI
  *
@@ -162,7 +175,7 @@ public class AgentApiService {
  */
     
 	/**
- * GET /agent/{agentUri}/events
+ * GET /agents/{agentUri}/events
  * Returns list of RMap:Event URIs related to the Agent URI as JSON or PLAINTEXT.
  *
  * @param headers the HTTP request headers
@@ -185,7 +198,7 @@ public class AgentApiService {
     
    
 	/**
-	 * GET /agent/{agentUri}/discos
+	 * GET /agents/{agentUri}/discos
 	 * Returns list of URIs for RMap:DiSCOs that were created by the Agent URI as JSON or PLAINTEXT.
 	 *
 	 * @param headers the HTTP request headers

--- a/api/src/main/java/info/rmapproject/api/service/DiSCOApiService.java
+++ b/api/src/main/java/info/rmapproject/api/service/DiSCOApiService.java
@@ -84,7 +84,7 @@ public class DiSCOApiService {
 
     
 	/**
-	 * HEAD /disco
+	 * HEAD /discos
 	 * Returns DiSCO API information/link, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -97,7 +97,7 @@ public class DiSCOApiService {
     }
     
 	/**
-	* GET /disco
+	* GET /discos
 	* Returns link to DiSCO API information, and lists HTTP options.
 	*
 	* @return HTTP Response
@@ -112,7 +112,7 @@ public class DiSCOApiService {
     
 
 	/**
-	 * OPTIONS /disco
+	 * OPTIONS /discos
 	 * Returns DiSCO API information/link, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -136,7 +136,7 @@ public class DiSCOApiService {
     
 
 	/**
-	 * GET /disco/{discoUri}
+	 * GET /discos/{discoUri}
 	 * Returns requested RMap:DiSCO as RDF/XML, NQUADS, TURTLE or JSON-LD.
 	 *
 	 * @param header the HTTP request headers
@@ -167,7 +167,7 @@ public class DiSCOApiService {
  */
 
 	/**
- * GET /disco/{discoUri}/latest
+ * GET /discos/{discoUri}/latest
  * When successful, this returns the location of the latest version of the DiSCO as a 302 Found response
  *
  * @param header the HTTP request headers
@@ -198,7 +198,7 @@ public class DiSCOApiService {
 	 *-------------------------------
 	 */
      /**
-	 * HEAD /disco/{discoUri}
+	 * HEAD /discos/{discoUri}
 	 * Returns status information for specific DiSCO as a HTTP response header. 
 	 * Includes event list, versions, and URI
 	 *
@@ -223,7 +223,7 @@ public class DiSCOApiService {
  */ 
     
 	/**
- * POST /disco/
+ * POST /discos/
  * Creates new DiSCO from RDF/XML, JSON-LD or TURTLE.
  *
  * @param header the HTTP request headers
@@ -253,7 +253,7 @@ public class DiSCOApiService {
  */ 
 
 	/**
- * POST /disco/{discoid}
+ * POST /discos/{discoid}
  * Sets original DiSCO as inactive and creates a new DiSCO from RDF/XML, JSON-LD or TURTLE.
  *
  * @param header the HTTP request headers
@@ -285,7 +285,7 @@ public class DiSCOApiService {
  */
     
 	/**
- * GET /disco/{discoUri}/events
+ * GET /discos/{discoUri}/events
  * Returns list of RMap:Event URIs related to the DiSCO URI as JSON or PLAINTEXT.
  *
  * @param header the HTTP request headers
@@ -312,7 +312,7 @@ public class DiSCOApiService {
  */
     
   /**
-  * DELETE /disco/{discoUri}
+  * DELETE /discos/{discoUri}
   * Sets status of target RMap:DiSCO to "tombstoned".  It will still be stored in the triplestore
   * but won't be visible through the API.
   *
@@ -328,7 +328,7 @@ public class DiSCOApiService {
     }
 
 	/**
-	 * POST /disco/{discoUri}/inactivate
+	 * POST /discos/{discoUri}/inactivate
 	 * Sets status of target RMap:DiSCO to "inactive".  It will still be stored in the triplestore
 	 * and will still be visible through the API for certain requests.
 	 *
@@ -352,7 +352,7 @@ public class DiSCOApiService {
  */
     
 	/**
- * GET /disco/{discoUri}/allversions
+ * GET /discos/{discoUri}/allversions
  * Returns list of all RMap:DiSCO version URIs as JSON or PLAIN TEXT.
  *
  * @param header the HTTP request headers
@@ -371,7 +371,7 @@ public class DiSCOApiService {
     
     
 	/**
-	 * GET /disco/{discoUri}/agentversions
+	 * GET /discos/{discoUri}/agentversions
 	 * Returns list of discoUri agent's RMap:DiSCO version URIs as JSON.
 	 *
 	 * @param header the HTTP request headers
@@ -389,7 +389,7 @@ public class DiSCOApiService {
     }
     
 	/**
-	 * GET /disco/{discoUri}/timemap
+	 * GET /discos/{discoUri}/timemap
 	 * Based on Memento standard, returns the DiSCO timemap version list with dates
 	 * This is presented as a list of link rels in the body of the response and 
 	 * relevant Memento links in the header.

--- a/api/src/main/java/info/rmapproject/api/service/EventApiService.java
+++ b/api/src/main/java/info/rmapproject/api/service/EventApiService.java
@@ -76,7 +76,7 @@ public class EventApiService {
  *-------------------------------
  */	
 	/**
- * GET /event
+ * GET /events
  * Returns link to Event API information, and lists HTTP options.
  *
  * @return HTTP Response
@@ -91,7 +91,7 @@ public class EventApiService {
     
 
 	/**
-	 * HEAD /event
+	 * HEAD /events
 	 * Returns Event API information/link, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -105,7 +105,7 @@ public class EventApiService {
     
 
 	/**
-	 * OPTIONS /event
+	 * OPTIONS /events
 	 * Returns Event API information/link, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -126,7 +126,7 @@ public class EventApiService {
  *-------------------------------
  */
 	/**
-	 * GET /event/{eventUri}
+	 * GET /events/{eventUri}
 	 * Returns requested RMap:Event as RDF/XML, JSON-LD, NQUADS, TURTLE.
 	 *
 	 * @param headers the HTTP request headers
@@ -159,7 +159,7 @@ public class EventApiService {
     
     
 	/**
-	 * GET /event/{eventUri}/discos
+	 * GET /events/{eventUri}/discos
 	 * Returns list of RMap:Statement URIs related to the RMap:Event URI as TEXT or JSON.
 	 *
 	 * @param headers the HTTP request headers
@@ -177,7 +177,7 @@ public class EventApiService {
     }
 
 	/**
-	 * GET /event/{eventUri}/agents
+	 * GET /events/{eventUri}/agents
 	 * Returns list of RMap:Statement URIs related to the RMap:Event URI as TEXT or JSON.
 	 *
 	 * @param headers the HTTP request headers
@@ -195,7 +195,7 @@ public class EventApiService {
     }
 
 	/**
-	 * GET /event/{eventUri}/resources
+	 * GET /events/{eventUri}/resources
 	 * Returns list of rdfs:Resource URIs related to the RMap:Event URI as TEXT or JSON.
 	 *
 	 * @param headers the HTTP request headers

--- a/api/src/main/java/info/rmapproject/api/service/ResourceApiService.java
+++ b/api/src/main/java/info/rmapproject/api/service/ResourceApiService.java
@@ -82,7 +82,7 @@ public class ResourceApiService {
  *-------------------------------
  */	
 	/**
-	 * GET /resource
+	 * GET /resources
 	 * Returns link to Resource API information, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -97,7 +97,7 @@ public class ResourceApiService {
         
 
 	/**
-	 * HEAD /resource
+	 * HEAD /resources
 	 * Returns Resource API information/link, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -111,7 +111,7 @@ public class ResourceApiService {
     
 
 	/**
-	 * OPTIONS /resource
+	 * OPTIONS /resources
 	 * Returns Resource API information/link, and lists HTTP options.
 	 *
 	 * @return HTTP Response
@@ -125,7 +125,7 @@ public class ResourceApiService {
     }   
 
 	/**
-	 * GET /resource/{resourceUri}/events[?agents={agentsCsv}&from={dateFrom}&until={dateTo}]
+	 * GET /resources/{resourceUri}/events[?agents={agentsCsv}&from={dateFrom}&until={dateTo}]
 	 * Returns list of all RMap:Event URIs related to the rdfs:Resource URI as JSON or PLAIN TEXT.
 	 *
 	 * @param headers the HTTP request headers
@@ -147,7 +147,7 @@ public class ResourceApiService {
     }
 		
 	/**
-	 * GET /resource/{resourceUri}/agents[?agents={agentsCsv}&from={dateFrom}&until={dateTo}]
+	 * GET /resources/{resourceUri}/agents[?agents={agentsCsv}&from={dateFrom}&until={dateTo}]
 	 * Returns list of all RMap:Agent URIs related to the rdfs:Resource URI as JSON or PLAIN TEXT.
 	 *
 	 * @param headers the HTTP request headers
@@ -169,7 +169,7 @@ public class ResourceApiService {
     }
     
 	/**
-	 * GET /resource/{resourceUri}/discos[?status={status}&agents={agentsCsv}&from={dateFrom}&until={dateTo}]
+	 * GET /resources/{resourceUri}/discos[?status={status}&agents={agentsCsv}&from={dateFrom}&until={dateTo}]
 	 * Returns list of all RMap:DiSCO URIs related to the rdfs:Resource URI as JSON or PLAIN TEXT.
 	 *
 	 * @param headers the HTTP request headers

--- a/api/src/main/java/info/rmapproject/api/service/RootApiService.java
+++ b/api/src/main/java/info/rmapproject/api/service/RootApiService.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a 
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.api.service;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import info.rmapproject.api.exception.RMapApiException;
+import info.rmapproject.api.utils.LinkRels;
+import info.rmapproject.api.utils.PathUtils;
+
+/**
+ * Root of REST API service for RMap.
+ *
+ * @author khanson
+ */
+
+@Path("/")
+@Component
+public class RootApiService {
+
+	protected PathUtils pathUtils;
+	
+	@Autowired
+	public RootApiService(PathUtils pathUtils){
+		this.pathUtils=pathUtils;
+	}
+	
+	/**
+	 * GET /
+	 * Returns API information/link, and lists HTTP options.
+	 *
+	 * @return HTTP Response
+	 * @throws RMapApiException the RMap API exception
+	 */
+    @GET
+    @Path("/")
+    public Response apiGetApiDetails() throws RMapApiException {
+    	String docPath = pathUtils.getDocumentationPath();
+		Response response = Response.status(Response.Status.OK)
+				.entity("<strong>Welcome to the RMap API.</strong><br/>API documentation can be found at <a href=\"" + docPath + "\">" + docPath + "</a>")
+				.allow(HttpMethod.HEAD,HttpMethod.OPTIONS,HttpMethod.GET)
+				.link(pathUtils.getDocumentationPath(),LinkRels.DC_DESCRIPTION)	
+				.build();
+	    return response;
+    }
+   
+}

--- a/api/src/main/webapp/WEB-INF/beans.xml
+++ b/api/src/main/webapp/WEB-INF/beans.xml
@@ -42,6 +42,7 @@
 	
     <jaxrs:server id="services" address="/">
         <jaxrs:serviceBeans>
+            <bean class="info.rmapproject.api.service.RootApiService"/>   
             <bean class="info.rmapproject.api.service.DiSCOApiService"/>   
             <bean class="info.rmapproject.api.service.EventApiService"/>   
             <bean class="info.rmapproject.api.service.AgentApiService"/>   

--- a/api/src/test/java/info/rmapproject/api/service/RootApiServiceTest.java
+++ b/api/src/test/java/info/rmapproject/api/service/RootApiServiceTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a 
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.api.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import info.rmapproject.api.ApiDataCreationTestAbstract;
+
+public class RootApiServiceTest extends ApiDataCreationTestAbstract{
+	
+	@Autowired
+	RootApiService rootApiService;
+	
+	/**
+	 * Test the RMap Resource RDF stmts API call
+	 */
+	@Test
+	public void testApiGetApiDetailsFromRoot() throws Exception {
+		
+		Response response = rootApiService.apiGetApiDetails();
+
+		assertNotNull(response);
+		String body = response.getEntity().toString();
+
+		assertEquals(200, response.getStatus());
+		assertTrue(body.contains("Welcome"));
+
+	}
+
+}


### PR DESCRIPTION
Closes issue #4
Also:
- Corrected the paths in the comments of the API Service classes 
- Added missing `GET /agents` message
- Replaced description json with URL to documentation.