### PR TITLE
Added versions to plugins [do not merge - retesting]

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -317,6 +317,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build-helper.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>reserve-port</id>
@@ -552,6 +553,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.20.1</version>
                 <configuration>
                     <systemProperties>
                         <derby.system.home>${derby.home}</derby.system.home>


### PR DESCRIPTION
Added some version declarations in plugins - their absence was causing build problems in integration module. 
The problem was discovered after removing maven repo.