### PR TITLE
Assign RMap events to Kafka partitions based on progenitor lineage URI

### DIFF
--- a/indexing-solr/src/main/java/info/rmapproject/indexing/kafka/LineagePartitioner.java
+++ b/indexing-solr/src/main/java/info/rmapproject/indexing/kafka/LineagePartitioner.java
@@ -1,0 +1,151 @@
+package info.rmapproject.indexing.kafka;
+
+import info.rmapproject.core.model.event.RMapEvent;
+import info.rmapproject.core.model.event.RMapEventTargetType;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.String.format;
+
+/**
+ * Insures that every RMap event associated with a specific lineage will be assigned to the same partition, assuming
+ * that the number of available Kafka partitions is constant. This class uses a hash-based algorithm to determine the
+ * partition; the hash code of the RMap event's {@link RMapEvent#getLineageProgenitor() lineage URI} is calculated,
+ * modulo the number of available partitions.
+ * <p>
+ * Note that if the number of partitions is changed (e.g. an administrator adds more partitions), then there is no
+ * longer the guarantee that the events for a lineage are contained within a single partition.  Adding partitions to
+ * the Kafka cluster is something that should be seriously considered, as a full re-build of the Kafka topic may be
+ * necessary.
+ * </p>
+ * <p>
+ * There may be times when the assigned partition is not available.  This can occur when the leader for a partition is
+ * unavailable.  In this case, there is probably a serious problem with the health of the Kakfa cluster.  When the
+ * assigned partition is not available, a {@code RuntimeException} is thrown, instead of breaking the "one lineage
+ * contained within a single partition" guarantee.
+ * </p>
+ * <p>
+ * If the RMap event does <em>not</em> have a progenitor lineage URI (this is the case if the event target type is
+ * not a {@link RMapEventTargetType#DISCO}), it is simply assigned to a partition based on the hashcode of the event
+ * object.  Because these objects do not participate in a lineage, there is no need to be concerned about which
+ * partition they end up in.
+ * </p>
+ */
+public class LineagePartitioner implements Partitioner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LineagePartitioner.class);
+
+    // FIXME: inject the value of the rmapcore.producer.topic property from rmapcore.properties,
+    static final String TOPIC = "rmap-event-topic";
+
+    private static final String ERR_INCORRECT_TYPE = "Unable to assign a partition to object of type '%s' received " +
+            "on topic '%s': only instances of RMapEvent can be assigned by this partitioner.";
+
+    private static final String ERR_UNAVAILABLE_PARTITIONS = "Unable to assign RMap Event '%s' received on topic " +
+            "'%s' to a partition, because partition id '%s' is not available (is the leader for '%s', partition %s " +
+            "available?)";
+
+    private static final String ERR_PARTITION_CALCULATION = "Assigning object of type '%s' to a partition failed " +
+            "because an exception was encountered when calculating the lineage progenitor hashcode: %s";
+
+    /**
+     * Assigns a Kafka partition to the supplied RMap event based on the {@link RMapEvent#getLineageProgenitor() lineage
+     * progenitor}.
+     *
+     * @param topic      the Kafka topic the record is being sent to
+     * @param key        the record key
+     * @param keyBytes   the byte representation of the key
+     * @param value      the record value (an {@code RMapEvent})
+     * @param valueBytes the byte representation of the value
+     * @param cluster    encapsulates information about topics, nodes, and partitions in the Kafka cluster
+     * @return the partition identifier (zero-based)
+     */
+    @Override
+    public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+
+        if (!(value instanceof RMapEvent)) {
+            String msg = format(ERR_INCORRECT_TYPE, value.getClass().getName(), topic);
+            LOG.error(msg);
+            throw new RuntimeException(msg);
+        }
+
+        // Total number of partitions for the topic
+        int partCount = cluster.partitionCountForTopic(TOPIC);
+
+        try {
+            // The partition offset is a number between 0 and 'partCount - 1'.
+            // According to the javadoc for the partition(...) method, the partition id is zero-based.
+            // Therefore, the partition offset should be equal to the partition identifier.
+            AtomicInteger partitionId;
+            if (((RMapEvent) value).getEventTargetType() == RMapEventTargetType.DISCO) {
+                partitionId = new AtomicInteger(calculatePartitionIdUsingLineage((RMapEvent) value, partCount));
+            } else {
+                partitionId = new AtomicInteger(calculatePartitionIdUsingHash(((RMapEvent) value), partCount));
+            }
+
+            return cluster.availablePartitionsForTopic(TOPIC)
+                    .stream()
+                    .map(PartitionInfo::partition)
+                    .filter(candidateId -> candidateId == partitionId.get())
+                    .findFirst()
+                    .orElseThrow(() -> new RuntimeException(format(ERR_UNAVAILABLE_PARTITIONS,
+                            value, TOPIC, partitionId.get(), TOPIC, partitionId.get())));
+        } catch (Exception e) {
+            String msg = format(ERR_PARTITION_CALCULATION, value.getClass().getName(), e.getMessage());
+            LOG.error(msg, e);
+            throw new RuntimeException(msg, e);
+        }
+    }
+
+    /**
+     * Calculates the partition identifier based on the hash of the RMapEvent's lineage progenitor URI.
+     *
+     * @param event RMap event objects that target DiSCOs
+     * @param totalPartitionCountForTopic the total number of partitions configured for this topic
+     * @return the partition identifier this event should be assigned to
+     */
+    static int calculatePartitionIdUsingLineage(RMapEvent event, int totalPartitionCountForTopic) {
+        String normalizedLineageIri = event.getLineageProgenitor()
+                .getStringValue()
+                .trim()
+                .toLowerCase();
+        int partitionId = Math.abs(normalizedLineageIri.hashCode()) % totalPartitionCountForTopic;
+        LOG.trace("Calculated partition id {} for event (target type: {}, lineage {}, uri {}) lineage hashcode {} " +
+                        "and partition count {}", partitionId, event.getEventTargetType(), normalizedLineageIri,
+                event.getId(), normalizedLineageIri.hashCode(), totalPartitionCountForTopic);
+        return partitionId;
+    }
+
+    /**
+     * Calculates the partition identifier based on the hash of the event object itself.  This method is used when
+     * assigning a partition to an RMap event that does not have a lineage progenitor URI.
+     *
+     * @param event RMap event objects that target objects <em>other than</em> DiSCOs
+     * @param totalPartitionCountForTopic the total number of partitions configured for this topic
+     * @return the partition identifier this event should be assigned to
+     */
+    static int calculatePartitionIdUsingHash(RMapEvent event, int totalPartitionCountForTopic) {
+        int partitionId = Math.abs(event.hashCode()) % totalPartitionCountForTopic;
+        LOG.trace("Calculated partition id {} for event (target type: {}, uri {}) using event hashcode {} and " +
+                        "partition count {}",
+                partitionId, event.getEventTargetType(), event.getId(), event.hashCode(),
+                totalPartitionCountForTopic);
+        return partitionId;
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        // no-op
+    }
+}

--- a/indexing-solr/src/main/java/info/rmapproject/indexing/kafka/LineagePartitioner.java
+++ b/indexing-solr/src/main/java/info/rmapproject/indexing/kafka/LineagePartitioner.java
@@ -1,3 +1,22 @@
+/*******************************************************************************
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
 package info.rmapproject.indexing.kafka;
 
 import info.rmapproject.core.model.event.RMapEvent;

--- a/indexing-solr/src/test/java/info/rmapproject/indexing/kafka/LineagePartitionerTest.java
+++ b/indexing-solr/src/test/java/info/rmapproject/indexing/kafka/LineagePartitionerTest.java
@@ -1,0 +1,202 @@
+package info.rmapproject.indexing.kafka;
+
+import info.rmapproject.core.model.RMapIri;
+import info.rmapproject.core.model.event.RMapEvent;
+import info.rmapproject.core.model.event.RMapEventTargetType;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static info.rmapproject.indexing.kafka.LineagePartitioner.TOPIC;
+import static info.rmapproject.indexing.kafka.LineagePartitioner.calculatePartitionIdUsingLineage;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class LineagePartitionerTest {
+
+    private final byte[] EMPTY_BYTE_ARRAY = {};
+
+    private LineagePartitioner underTest = new LineagePartitioner();
+
+    /**
+     * RMap event that targets a disco.  Events targeting discos have non-null lineage progenitors
+     */
+    private RMapEvent discoEvent = mock(RMapEvent.class);
+
+    /**
+     * RMap event that targets an agent.  Events targeting non-disco types will have null lineage progenitors
+     */
+    private RMapEvent agentEvent = mock(RMapEvent.class);
+
+    /**
+     * Collaborating object for the Kafka Cluster that represents the leader of an arbitrary number of partitions.
+     */
+    private Node leader = mock(Node.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(discoEvent.getEventTargetType()).thenReturn(RMapEventTargetType.DISCO);
+        when(discoEvent.getLineageProgenitor()).thenReturn(new RMapIri(URI.create("http://rmapproject.info/event/1")));
+
+        when(agentEvent.getEventTargetType()).thenReturn(RMapEventTargetType.AGENT);
+
+        // Collaborator that must be mocked since the Cluster class is final.  It must have a node ID, and must be
+        // returned as the leader of the lone partition
+        Node node = mock(Node.class);
+        when(node.id()).thenReturn(10); // who cares, the node id just needs to be present
+    }
+
+    /**
+     * Insure an RMap event is assigned to the expected partition when there is only a single partition in the Kafka
+     * cluster for the RMap topic.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAssignSinglePartition() throws Exception {
+        int expectedPartitionId = 0;
+
+        // Mock a single PartitionInfo representing the single partition in the RMap event topic
+        PartitionInfo partitionInfo = mock(PartitionInfo.class);
+        when(partitionInfo.partition()).thenReturn(expectedPartitionId);
+        when(partitionInfo.topic()).thenReturn(TOPIC);
+        when(partitionInfo.leader()).thenReturn(leader);
+        List<PartitionInfo> partitions = singletonList(partitionInfo);
+
+        // Can't mock Cluster, it's final
+        Cluster clusterInfo = new Cluster("clusterId", singletonList(leader), partitions,
+                emptySet(), emptySet(), null);
+
+        // Assign the partition and verify it against the expected value
+        // (any number modulo 1 is 0)
+        assertEquals(expectedPartitionId,
+                underTest.partition(TOPIC, "fooKey", EMPTY_BYTE_ARRAY, discoEvent, EMPTY_BYTE_ARRAY, clusterInfo));
+    }
+
+    /**
+     * Insure an RMap event is assigned to the expected partition when there is six partitions in the Kafka cluster for
+     * the RMap topic.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAssignWithSixPartitions() throws Exception {
+        int expectedPartitionId = 4;
+        List<PartitionInfo> partitions = new ArrayList<>();
+
+        // Mock a six PartitionInfo objects representing the six partitions in the RMap event topic
+        // Each PartitionInfo will have the above Node as its leader
+        for (int partitionId = 0; partitionId < 6; partitionId++) {
+            PartitionInfo partitionInfo = mock(PartitionInfo.class);
+            when(partitionInfo.partition()).thenReturn(partitionId);
+            when(partitionInfo.topic()).thenReturn(TOPIC);
+            when(partitionInfo.leader()).thenReturn(leader);
+            partitions.add(partitionInfo);
+        }
+
+        Cluster clusterInfo = new Cluster("clusterId", singletonList(leader), partitions,
+                emptySet(), emptySet(), null);
+
+        // Assign the partition and verify it against the expected value
+        assertEquals(expectedPartitionId,
+                underTest.partition(TOPIC, "fooKey", EMPTY_BYTE_ARRAY, discoEvent, EMPTY_BYTE_ARRAY, clusterInfo));
+    }
+
+    /**
+     * Insure that the logic calculating the partition id works over a range of partition counts
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCalculatePartitionId() throws Exception {
+        assertEquals(0, calculatePartitionIdUsingLineage(discoEvent, 1));
+        assertEquals(0, calculatePartitionIdUsingLineage(discoEvent, 2));
+        assertEquals(1, calculatePartitionIdUsingLineage(discoEvent, 3));
+        assertEquals(0, calculatePartitionIdUsingLineage(discoEvent, 4));
+        assertEquals(1, calculatePartitionIdUsingLineage(discoEvent, 5));
+        assertEquals(4, calculatePartitionIdUsingLineage(discoEvent, 6));
+        assertEquals(4, calculatePartitionIdUsingLineage(discoEvent, 7));
+        assertEquals(4, calculatePartitionIdUsingLineage(discoEvent, 8));
+        assertEquals(7, calculatePartitionIdUsingLineage(discoEvent, 9));
+        assertEquals(6, calculatePartitionIdUsingLineage(discoEvent, 10));
+    }
+
+    /**
+     * Insure that the logic calculating the partition id is idempotent.  The same inputs should yield the same output.
+     * That is, for a specified progenitor lineage URI, and number of partitions in the topic, the assigned partition
+     * id should be the same for multiple invocations of the
+     * {@link LineagePartitioner#calculatePartitionIdUsingLineage(RMapEvent, int)} method.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCalculatePartitionIdIdempotent() throws Exception {
+        assertEquals(0, calculatePartitionIdUsingLineage(discoEvent, 4));
+        assertEquals(0, calculatePartitionIdUsingLineage(discoEvent, 4));
+    }
+
+    /**
+     * Insure a runtime exception is thrown when a partition is not available (occurs when a partition has no leader).
+     *
+     * @throws Exception
+     */
+    @Test(expected = RuntimeException.class)
+    public void testAssignToUnavailablePartition() throws Exception {
+        List<PartitionInfo> partitions = new ArrayList<>();
+
+        for (int partitionId = 0; partitionId < 3; partitionId++) {
+            PartitionInfo partitionInfo = mock(PartitionInfo.class);
+            when(partitionInfo.partition()).thenReturn(partitionId);
+            when(partitionInfo.topic()).thenReturn(TOPIC);
+
+            // Partition ID 1 is the partition id that will be calculated for the supplied iri and number of partitions
+            // Prevent this partition from being considered active by returning null when asked for its leader
+            if (partitionId != 1) {
+                when(partitionInfo.leader()).thenReturn(leader);
+            }
+            partitions.add(partitionInfo);
+        }
+
+        // Can't mock Cluster, it's final
+        Cluster clusterInfo = new Cluster("clusterId", singletonList(leader), partitions,
+                emptySet(), emptySet(), null);
+
+        // Will throw a RuntimeException because the assigned partition is not available.
+        underTest.partition(TOPIC, "fooKey", EMPTY_BYTE_ARRAY, discoEvent, EMPTY_BYTE_ARRAY, clusterInfo);
+    }
+
+    /**
+     * Insure a RuntimeException is thrown when there is some other error encountered calculating the partition id.
+     *
+     * @throws Exception
+     */
+    @Test(expected = RuntimeException.class)
+    public void testUnexpectedExceptionWhenCalculatingHashcode() throws Exception {
+        PartitionInfo partitionInfo = mock(PartitionInfo.class);
+        when(partitionInfo.partition()).thenReturn(0);
+        when(partitionInfo.topic()).thenReturn(TOPIC);
+        List<PartitionInfo> partitions = singletonList(partitionInfo);
+
+        RMapEvent event = mock(RMapEvent.class);
+        // This will cause an NPE to be thrown in the partition calculation logic
+        when(event.getLineageProgenitor()).thenReturn(null);
+
+        // Can't mock Cluster, it's final
+        Cluster clusterInfo = new Cluster("clusterId", singletonList(leader), partitions,
+                emptySet(), emptySet(), null);
+
+        underTest.partition(TOPIC, "fooKey", EMPTY_BYTE_ARRAY, event, EMPTY_BYTE_ARRAY, clusterInfo);
+    }
+}

--- a/indexing-solr/src/test/java/info/rmapproject/indexing/kafka/LineagePartitionerTest.java
+++ b/indexing-solr/src/test/java/info/rmapproject/indexing/kafka/LineagePartitionerTest.java
@@ -1,3 +1,22 @@
+/*******************************************************************************
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
 package info.rmapproject.indexing.kafka;
 
 import info.rmapproject.core.model.RMapIri;

--- a/indexing-solr/src/test/resources/event-producer.properties
+++ b/indexing-solr/src/test/resources/event-producer.properties
@@ -3,3 +3,4 @@ client.id = rmap-event-producer
 enable.idempotence = true
 compression.type = gzip
 linger.ms = 100
+partitioner.class = info.rmapproject.indexing.kafka.LineagePartitioner

--- a/integration/src/main/resources/event-producer.properties
+++ b/integration/src/main/resources/event-producer.properties
@@ -3,3 +3,4 @@ client.id = rmap-event-producer
 enable.idempotence = true
 compression.type = gzip
 linger.ms = 100
+partitioner.class = info.rmapproject.indexing.kafka.LineagePartitioner


### PR DESCRIPTION
This implements a Kafka Partitioner that insures events pertaining to a lineage go to the same Kafka partition.  Events that do not have a progenitor lineage URI are simply assigned based on the hash code of the event object.

Note that this implementation is sensitive to the number of Kafka partitions that are configured for the RMap event topic.  If the number of partitions changes, then the algorithm implemented in this commit will end up assigning events that once went to PartitionA to go to PartitionB.  This will break the guarantee that events pertaining to a lineage are contained within a single partition.  Care should be taken if the number of partitions for the RMap event topic are ever increased in the future.

Includes unit test.

This closes #144 and #138.