### PR TITLE
Change default profiles to match production defaults

### DIFF
--- a/api/src/main/webapp/WEB-INF/web.xml
+++ b/api/src/main/webapp/WEB-INF/web.xml
@@ -9,7 +9,7 @@
   </context-param>
   <context-param>
       <param-name>spring.profiles.default</param-name>
-      <param-value>default,persistent-db,http-idservice,http-triplestore,http-solr,prod-kafka,auto-start-indexing</param-value>
+      <param-value>default,persistent-db,ark-idservice,http-triplestore,http-solr,prod-kafka,auto-start-indexing</param-value>
   </context-param>
   <listener>
     <listener-class>

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -9,7 +9,7 @@
     </context-param>
     <context-param>
         <param-name>spring.profiles.default</param-name>
-        <param-value>default,persistent-db,http-idservice,http-triplestore,http-solr,prod-kafka,auto-start-indexing</param-value>
+        <param-value>default,persistent-db,ark-idservice,http-triplestore,http-solr,prod-kafka,auto-start-indexing</param-value>
     </context-param>
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>


### PR DESCRIPTION
Avoids the need to override the settings using catalina.properites.