### PR TITLE
Fix snippet length and other minor issues

### DIFF
--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/AccountController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/AccountController.java
@@ -166,6 +166,7 @@ public class AccountController {
 		//refresh session record and attribute
 		user = this.userMgtService.getUserById(user.getUserId()); 
 		session.setAttribute("user",user);
+		model.addAttribute("user", user);
 		model.addAttribute("userSettings",user);
 		model.addAttribute("notice", "User settings have been saved.");
 		return "user/settings"; 		

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/ResourceDisplayController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/ResourceDisplayController.java
@@ -37,7 +37,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import info.rmapproject.core.exception.RMapObjectNotFoundException;
 import info.rmapproject.core.model.RMapTriple;
 import info.rmapproject.core.model.request.RMapSearchParams;
 import info.rmapproject.core.model.request.RMapSearchParamsFactory;

--- a/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
@@ -562,7 +562,7 @@ public class DataDisplayServiceImpl implements DataDisplayService {
 		
 		graph.addNode(sAgentUri, agentDTO.getName(), agentNodeType);
 		graph.addNode(agentDTO.getIdProvider(), agentNodeType);
-		graph.addNode(agentDTO.getAuthId(), WebappUtils.getNodeType(new URI(Terms.RMAP_USERAUTHID_PATH)));
+		graph.addNode(agentDTO.getAuthId(), Constants.NODETYPE_NOTYPE);
 		
 		graph.addEdge(sAgentUri, agentDTO.getIdProvider(), Terms.RMAP_IDENTITYPROVIDER_PATH);
 		graph.addEdge(sAgentUri, agentDTO.getAuthId(), Terms.RMAP_USERAUTHID_PATH);

--- a/webapp/src/main/java/info/rmapproject/webapp/utils/WebappUtils.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/utils/WebappUtils.java
@@ -313,10 +313,9 @@ public class WebappUtils {
 	/**
 	 * Formats a snippet so that it is cut at a max number of characters, "<" and ">" are converted to html
 	 * and the "strong" tags aren't left open after this cut. 
-	 * NOTE: that there are several known imperfections here that might result in some variation 
+	 * NOTE: there is a known imperfections here that might result in some variation 
 	 * in string length e.g. a very long match with lots of highlighting may end up longer than 
-	 * other strings... also it truncates from the string start rather than around the highlight which could 
-	 * result in no highlighted text being shown if highlighting is at end of string.
+	 * other strings.
 	 * TODO: improve this based on note above, might be something that can be configured using solr?
 	 * @param text string to be formatted
 	 * @param max maximum length of display text (excludes html tags in length)
@@ -330,7 +329,17 @@ public class WebappUtils {
 		int numHLs = StringUtils.countMatches(text,HL_PREFIX);
 		int hlSpace = (HL_PREFIX.length() + HL_POSTFIX.length()) * numHLs;
 		int actualMax = max+hlSpace;
-		if (text.length() > actualMax){ //shorten
+		
+		int firstPrefix = snippet.indexOf(HL_PREFIX);
+		if (firstPrefix>actualMax) { //first match won't appear in snippet
+			//so let's put the first match around the halfway point of the snippet
+			snippet = snippet.substring(firstPrefix-Math.abs(actualMax/2));
+			//clean up partial word if there is one
+			int firstSpace = snippet.indexOf(" ");
+			firstPrefix = snippet.indexOf(HL_PREFIX);
+			snippet = snippet.substring((firstSpace>0 && firstSpace < firstPrefix) ? firstSpace+1 : 0);
+		}
+		if (snippet.length() > actualMax){ //shorten
 			int lastPostfixAfterMax = snippet.indexOf(HL_POSTFIX, (max + HL_PREFIX.length()));
 			if (lastPostfixAfterMax>0 && lastPostfixAfterMax < actualMax){ 
 				//close to cut point, we should end here instead

--- a/webapp/src/main/webapp/includes/js/pagecontrol.js
+++ b/webapp/src/main/webapp/includes/js/pagecontrol.js
@@ -297,7 +297,12 @@ $(window).load(function() {
 		var offset = $("#nodeInfoNext").data("offset");
 		loadNodeInfoBatch(offset, status);
 	});		
-		
+	
+	// x-out node info popup
+	$(document).on("click","#closeNodeInfo", function() {
+		closeNodeInfo();
+	});
+			
 	$(document).on("click", "[name='chkIncludeInactive']", function() {
 		if($(this).is(":checked")) {
 	    	updateUrlParameter("status", "all");	

--- a/webapp/src/main/webapp/includes/js/searchcontrol.js
+++ b/webapp/src/main/webapp/includes/js/searchcontrol.js
@@ -39,6 +39,7 @@ $( function() {
 	});
 	
 	$('[name="searchForm"]').submit(function(){
+		document.searchForm["page"].value=0;	
 		$(':input[value=""]').attr('disabled', true);
 	});
 		

--- a/webapp/src/test/java/info/rmapproject/webapp/utils/WebappUtilsTest.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/utils/WebappUtilsTest.java
@@ -73,7 +73,6 @@ public class WebappUtilsTest extends WebTestAbstract {
 		assertTrue(nodeType.equals("Text"));
 	}
 
-
 	/**
 	 * Test formatting of snippet
 	 *
@@ -98,15 +97,21 @@ public class WebappUtilsTest extends WebTestAbstract {
 		assertEquals(expected,formattedSnippet);	
 		formattedSnippet = WebappUtils.formatSnippet(snippet1, 36);
 		assertEquals(expected + " ",formattedSnippet);
-				
-		/*demonstrates the problem with a string where highlight is out of range of string size... ideally the highlights would be visible part of string
-		 * and the string would not be longer due to highlight tags being out of range*/
-		String snippet2="<http://dx.doi.org/10.1109/InPar.2012.6339604> <http://purl.org/dc/terms/isPartOf> ##$<ark:/35911/amsid/6330715>$## .";
-		expected="&lt;http://dx.doi.org/10.1109/InPar.2012.6339604&gt; &lt;http://purl.org/dc/terms/isPartOf&gt;";
-		formattedSnippet = WebappUtils.formatSnippet(snippet2, 76);
-		assertEquals(expected,formattedSnippet);
 	}
 
+
+	/**
+	 * Test formatting of snippet where highlight is beyond the snippet limit 
+	 *
+	 * @throws Exception the exception
+	 */
+	@Test
+	public void testFormatSnippetLongStart() throws Exception {
+		String snippet2="<http://dx.doi.org/10.1109/InPar.2012.6339604> <http://purl.org/dc/terms/isPartOf> ##$<ark:/35911/amsid/6330715>$## .";
+		String expected="&lt;http://purl.org/dc/terms/isPartOf&gt; <strong>&lt;ark:/35911/amsid/6330715&gt;</strong> .";
+		String formattedSnippet = WebappUtils.formatSnippet(snippet2, 76);
+		assertEquals(expected,formattedSnippet);		
+	}
 
 	
 	


### PR DESCRIPTION
A handful of minor GUI fixes
- Snippets were not displaying highlighted text where first highlight was too far into the string.
- If you did a second search while on page 2 of search results, the page number did not reset.
- Agent graph had authId set as type "other" instead of "no type"
- Added missing close node info popup command to pagecontrol.js
- Ensure session use information is refreshed after setting update
- Removed unused import