### PR TITLE
Copy logback.xml from integration to webapp and api modules

### DIFF
--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -1,0 +1,52 @@
+<configuration>
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>
+        %d{HH:mm:ss.SSS} [%10.10thread] %-5level [%15.-15C{0}] - %msg%n
+      </pattern>
+    </encoder>
+    <target>System.err</target>
+  </appender>
+  <root level="WARN">
+    <appender-ref ref="STDERR" />
+  </root>
+  <logger name="org.springframework" additivity="false" level="${org.springframework.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="org.springframework.jdbc" additivity="false" level="${org.springframework.jdbc.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="org.hibernate" additivity="false" level="${org.hibernate.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="info.rmapproject" additivity="false" level="${info.rmapproject.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="info.rmapproject.indexing" additivity="false" level="${info.rmapproject.indexing.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="info.rmapproject.integration" additivity="false" level="${info.rmapproject.integration.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="org.eclipse.rdf4j" additivity="false" level="${org.eclipse.rdf4j.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="kafka" additivity="false" level="${kafka.level:-WARN}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+  <logger name="org.springframework.kafka" additivity="false" level="${org.springframework.kafka.level:-WARN}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+  <logger name="org.apache.kafka" additivity="false" level="${org.apache.kafka.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="org.apache.kafka.clients.NetworkClient" additivity="false" level="${org.apache.kafka.clients.NetworkClient:-ERROR}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+  <logger name="org.apache.kafka.common.utils.AppInfoParser" additivity="false" level="${org.apache.kafka.common.utils.AppInfoParser:-ERROR}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+  <logger name="org.apache.kafka.clients.producer.internals" additivity="false" level="${org.apache.kafka.clients.producer.internals:-ERROR}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+</configuration>

--- a/webapp/src/main/resources/logback.xml
+++ b/webapp/src/main/resources/logback.xml
@@ -1,0 +1,52 @@
+<configuration>
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>
+        %d{HH:mm:ss.SSS} [%10.10thread] %-5level [%15.-15C{0}] - %msg%n
+      </pattern>
+    </encoder>
+    <target>System.err</target>
+  </appender>
+  <root level="WARN">
+    <appender-ref ref="STDERR" />
+  </root>
+  <logger name="org.springframework" additivity="false" level="${org.springframework.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="org.springframework.jdbc" additivity="false" level="${org.springframework.jdbc.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="org.hibernate" additivity="false" level="${org.hibernate.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="info.rmapproject" additivity="false" level="${info.rmapproject.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="info.rmapproject.indexing" additivity="false" level="${info.rmapproject.indexing.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="info.rmapproject.integration" additivity="false" level="${info.rmapproject.integration.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="org.eclipse.rdf4j" additivity="false" level="${org.eclipse.rdf4j.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="kafka" additivity="false" level="${kafka.level:-WARN}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+  <logger name="org.springframework.kafka" additivity="false" level="${org.springframework.kafka.level:-WARN}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+  <logger name="org.apache.kafka" additivity="false" level="${org.apache.kafka.level:-WARN}">
+    <appender-ref ref="STDERR" />
+  </logger>
+  <logger name="org.apache.kafka.clients.NetworkClient" additivity="false" level="${org.apache.kafka.clients.NetworkClient:-ERROR}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+  <logger name="org.apache.kafka.common.utils.AppInfoParser" additivity="false" level="${org.apache.kafka.common.utils.AppInfoParser:-ERROR}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+  <logger name="org.apache.kafka.clients.producer.internals" additivity="false" level="${org.apache.kafka.clients.producer.internals:-ERROR}">
+    <appender-ref ref="STDERR"/>
+  </logger>
+</configuration>


### PR DESCRIPTION
logback.xml is needed to set log levels on live apps, previously it was only available in integration. Copied it to the relevant modules.