### PR TITLE
Fixed resource label and DiSCO types

### DIFF
--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/ResourceDisplayController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/ResourceDisplayController.java
@@ -24,6 +24,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.List;
 
+import org.jsoup.Jsoup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -114,9 +115,12 @@ public class ResourceDisplayController {
 		RMapSearchParams params = generateSearchParams(status, 0);
 		
 		List<URI> resourceTypes = dataDisplayService.getResourceRDFTypes(new URI(sResourceUri),params);
-	    
+		String resourceLabel = dataDisplayService.getResourceLabel(sResourceUri,params);
+		if (resourceLabel!=null){
+			resourceLabel = Jsoup.parse(resourceLabel).text();
+		}
+	    model.addAttribute("RESOURCELABEL", resourceLabel); 
 	    model.addAttribute("RESOURCEURI", sResourceUri); 
-	    model.addAttribute("RESOURCELABEL", dataDisplayService.getResourceLabel(sResourceUri,params)); 
 	    model.addAttribute("RESOURCE_TYPES", resourceTypes);
 	    model.addAttribute("PAGEPATH", "resources");
 	 	    

--- a/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/service/DataDisplayServiceImpl.java
@@ -246,7 +246,7 @@ public class DataDisplayServiceImpl implements DataDisplayService {
 				List<URI> subjTypes = null;
 				List<URI> objTypes = null;
 				if (typeMap!=null && typeMap.getCollection(subject)!=null) {
-					new ArrayList<URI>(typeMap.getCollection(subject));
+					subjTypes = new ArrayList<URI>(typeMap.getCollection(subject));
 				}
 				if (typeMap!=null && typeMap.getCollection(object)!=null) {
 					objTypes = new ArrayList<URI>(typeMap.getCollection(object));

--- a/webapp/src/main/resources/typemappings.properties
+++ b/webapp/src/main/resources/typemappings.properties
@@ -9,6 +9,7 @@ http\://xmlns.com/foaf/0.1/Agent=Agent
 http\://xmlns.com/foaf/0.1/Person=Agent
 http\://xmlns.com/foaf/0.1/Organization=Agent
 http\://purl.org/dc/terms/Agent=Agent
+http\://purl.org/cerif/frapo/FundingAgency=Agent
 #Datasets
 http\://purl.org/spar/fabio/Dataset=Data
 http\://osf.io/terms/Data=Data
@@ -25,6 +26,7 @@ http\://osf.io/terms/Methods-and-measures=Text
 http\://osf.io/terms/Analysis=Text
 http\://osf.io/terms/Communication=Text
 http\://osf.io/terms/Instrumentation=Text
+http\://purl.org/spar/fabio/Journal=Text
 #Physical_objects
 http\://purl.org/dc/dcmitype/PhysicalObject=Physical_object
 #Code

--- a/webapp/src/main/webapp/includes/stylesheets/layout.css
+++ b/webapp/src/main/webapp/includes/stylesheets/layout.css
@@ -425,10 +425,10 @@ legend {
 
 label{padding-top:10px;}
 select {padding: 5px; border: 1px solid #ccc; margin: 5px 0; width:507px;}
-input[type=text] {padding: 5px; width:500px;border: 1px solid #ccc; margin: 5px 0;}
+input[type=text] {padding: 5px; min-width:300px; max-width:500px;width:100%;border: 1px solid #ccc; margin: 5px 0;}
 input[type=checkbox] {padding-left:2px;}
 textarea {width:500px;padding: 5px; margin: 5px 0; resize: vertical;}
-input[type=text].dateInput {width:100px; display:inline-block;}
+input[type=text].dateInput {width:100px; display:inline-block;min-width:100px;}
 input[readonly]{background-color:#f0f0f0;}
 
 #truncate {


### PR DESCRIPTION
Three small GUI fixes and added a few type mappings:
1) in the DiSCO graph, the types weren't being calculated correctly for the subject resource of a triple, fixed this.
2) when the Resource label included embedded HTML, the label would be displayed incorrectly. Added code to strip HTML from the Resource label
3) made text box width flexible - fixed with was messing with responsive layout
4) Added 2 more type mappings for IEEE DiSCOs - FundingAgency and Journal