### PR TITLE
Replace jdbc:initialize-database with a standard bean definition

### DIFF
--- a/auth/src/main/resources/spring-rmapauth-context.xml
+++ b/auth/src/main/resources/spring-rmapauth-context.xml
@@ -48,9 +48,19 @@
     <beans profile="inmemory-db">
         <context:property-placeholder location="classpath*:/inmemory-db.properties" ignore-unresolvable="true"/>
 
-        <jdbc:initialize-database enabled="true" data-source="basicDataSource" ignore-failures="ALL">
-            <jdbc:script location="${authdb.script.create-rmap-agent}" execution="INIT"/>
-        </jdbc:initialize-database>
+        <bean id="dataSourceInitializer" class="org.springframework.jdbc.datasource.init.DataSourceInitializer">
+            <property name="dataSource" ref="basicDataSource"/>
+            <property name="databasePopulator">
+                <bean class="org.springframework.jdbc.datasource.init.ResourceDatabasePopulator">
+                    <property name="scripts">
+                        <list>
+                            <value>${authdb.script.create-rmap-agent}</value>
+                        </list>
+                    </property>
+                </bean>
+            </property>
+        </bean>
+
 
         <bean id="inmemorySessionFactory" parent="sessionFactory">
             <property name="dataSource" ref="basicDataSource"/>

--- a/integration/src/main/resources/integration-db.xml
+++ b/integration/src/main/resources/integration-db.xml
@@ -10,9 +10,18 @@
     <beans profile="integration-db">
         <context:property-placeholder location="classpath*:/integration-db.properties" ignore-unresolvable="true"/>
 
-        <jdbc:initialize-database enabled="true" data-source="basicDataSource" ignore-failures="ALL">
-            <jdbc:script location="${authdb.script.create-rmap-agent}" execution="INIT"/>
-        </jdbc:initialize-database>
+        <bean id="dataSourceInitializer" class="org.springframework.jdbc.datasource.init.DataSourceInitializer">
+            <property name="dataSource" ref="basicDataSource"/>
+            <property name="databasePopulator">
+                <bean class="org.springframework.jdbc.datasource.init.ResourceDatabasePopulator">
+                    <property name="scripts">
+                        <list>
+                            <value>${authdb.script.create-rmap-agent}</value>
+                        </list>
+                    </property>
+                </bean>
+            </property>
+        </bean>
 
         <bean id="integrationSessionFactory" parent="sessionFactory">
             <property name="dataSource" ref="basicDataSource"/>


### PR DESCRIPTION
The bean definition deliberately excludes the (unused) databaseCleaner property.

The bean definition parser for `jdbc:initialize-database` will set the `databaseCleaner` property of `DataSourceInitializer` even when no `DESTROY` scripts have been set.  The (impotent) cleaner will be executed when `destroy()` is called, leading to the connection exception (because Postgres is no longer available).

Closes #213.