### PR TITLE
Increase Tomcat container timeout

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -307,6 +307,7 @@
                     <container>
                         <containerId>tomcat8x</containerId>
                         <type>installed</type>
+						<timeout>180000</timeout>
                         <artifactInstaller>
                             <groupId>org.apache.tomcat</groupId>
                             <artifactId>tomcat</artifactId>


### PR DESCRIPTION
Increases timeout for Tomcat container. This fixes an intermittent error that happens when building integration module:
`
[ERROR] Failed to execute goal org.codehaus.cargo:cargo-maven2-plugin:1.6.3:start (start-container) on project rmap-integration: Cannot start container [org.codehaus.cargo.container.tomcat.Tomcat8xInstalledLocalContainer@12cfc095]:
Deployable [http://localhost:61237/cargocpc/index.html] failed to finish deploying within the timeout period [120000]. The Deployable state is thus unknown.
`