### PR TITLE
Update Kafka producer and consumer configurations to read properties from the primary RMap configuration file

### DIFF
--- a/integration/src/main/resources/rmap.properties
+++ b/integration/src/main/resources/rmap.properties
@@ -76,4 +76,3 @@ rdf4jhttp.repository.password=
 #rmapweb.institution-logo=/includes/images/instance_logo.png
 
 rmap.solr.url=${rmap.solr.url}
-bootstrap.servers=192.168.99.100:29029

--- a/kafka-shared/src/main/resources/event-consumer.properties
+++ b/kafka-shared/src/main/resources/event-consumer.properties
@@ -1,4 +1,3 @@
-bootstrap.servers = ${bootstrap.servers}
 group.id = shared-consumer-group-1
 #client.id = shared-consumer-1
 auto.offset.reset = earliest

--- a/kafka-shared/src/main/resources/event-producer.properties
+++ b/kafka-shared/src/main/resources/event-producer.properties
@@ -1,4 +1,3 @@
-bootstrap.servers = ${bootstrap.servers}
 client.id = rmap-event-producer
 enable.idempotence = true
 compression.type = gzip

--- a/kafka-shared/src/main/resources/rmap-kafka-shared.xml
+++ b/kafka-shared/src/main/resources/rmap-kafka-shared.xml
@@ -11,7 +11,9 @@
 
         <context:property-placeholder ignore-unresolvable="true"/>
 
-        <util:properties id="producerProperties" location="classpath*:/event-producer.properties" local-override="true">
+        <util:properties id="producerProperties" location="classpath*:/event-producer.properties, ${rmap.configFile}" ignore-resource-not-found="true">
+            <!-- if the 'bootstrap.servers' property is present in properties referenced by the 'location' attribute,
+                 the value will override the value set below -->
             <prop key="bootstrap.servers">${bootstrap.servers}</prop>
         </util:properties>
 
@@ -33,7 +35,9 @@
             <property name="defaultTopic" value="${rmapcore.producer.topic}"/>
         </bean>
 
-        <util:properties id="consumerProperties" location="classpath:/event-consumer.properties" local-override="true">
+        <util:properties id="consumerProperties" location="classpath*:/event-consumer.properties, ${rmap.configFile}" ignore-resource-not-found="true">
+            <!-- if the 'bootstrap.servers' property is present in properties referenced by the 'location' attribute,
+                 the value will override the value set below -->
             <prop key="bootstrap.servers">${bootstrap.servers}</prop>
         </util:properties>
 


### PR DESCRIPTION
Also corrects the value of `bootstrap.servers` property for integration tests.