### PR TITLE
Use version 3.2.0 of the maven-war-plugin.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -252,6 +252,10 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+			</plugin>
         </plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <h2-mvstore.version>1.4.196</h2-mvstore.version>
         <ezid.version>1.0.1</ezid.version>
         <assertj.version>3.8.0</assertj.version>
+        <maven.war.plugin.version>3.2.0</maven.war.plugin.version>
     </properties>
 
     <build>
@@ -130,6 +131,13 @@
                     <artifactId>maven-remote-resources-plugin</artifactId>
                     <version>1.5</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${maven.war.plugin.version}</version>
+                </plugin>
+
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <org-json.version>20151123</org-json.version>
         <apache-cxf.version>3.1.4</apache-cxf.version>
         <derby.version>10.13.1.1</derby.version>
-        <build-helper.plugin.version>1.10</build-helper.plugin.version>
+        <build-helper.plugin.version>3.0.0</build-helper.plugin.version>
         <okhttp.version>3.8.0</okhttp.version>
         <ant.version>1.10.1</ant.version>
         <solr.version>6.6.2</solr.version>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -260,6 +260,12 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+            </plugin>
+
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
 Avoids a bug where test resources were getting packaged in deployed wars.