### PR TITLE
Convert HttpArkIdService.createId() to synchronized

### DIFF
--- a/core/src/main/java/info/rmapproject/core/idservice/HttpArkIdService.java
+++ b/core/src/main/java/info/rmapproject/core/idservice/HttpArkIdService.java
@@ -108,7 +108,7 @@ public class HttpArkIdService implements IdService {
     /* (non-Javadoc)
      * @see info.rmapproject.core.idservice.IdService#createId()
      */
-    public URI createId() throws Exception {
+    public synchronized URI createId() throws Exception {
         MVStore mvs = MVStore.open(idStoreFile);
         ezids = mvs.openMap(DATA);
 


### PR DESCRIPTION
This is a quick fix to resolve filelock issue found during stress tests on server.  This may have negative consequences for performance and need further review at a later date.