### PR TITLE
Removed double HTTP decoding of parameters passed into API or GUI

### DIFF
--- a/api/src/main/java/info/rmapproject/api/utils/PathUtils.java
+++ b/api/src/main/java/info/rmapproject/api/utils/PathUtils.java
@@ -291,15 +291,11 @@ public class PathUtils {
 	public static URI convertPathStringToURI(String sPathString) throws RMapApiException{
 		URI uri = null;
 		try {
-			sPathString = URLDecoder.decode(sPathString, "UTF-8");
 			sPathString = sPathString.replace(" ", "+");
 			sPathString = removeUriAngleBrackets(sPathString);
 			uri = new URI(sPathString);
 		}
 		catch (URISyntaxException ex){
-			throw RMapApiException.wrap(ex, ErrorCode.ER_PARAM_WONT_CONVERT_TO_URI);
-		}
-		catch (UnsupportedEncodingException ex){
 			throw RMapApiException.wrap(ex, ErrorCode.ER_PARAM_WONT_CONVERT_TO_URI);
 		}
 		return uri;

--- a/api/src/test/java/info/rmapproject/api/responsemgr/AgentResponseManagerTestIT.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/AgentResponseManagerTestIT.java
@@ -24,9 +24,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -109,7 +106,7 @@ public class AgentResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
     	Response response=null;
     		
 		try {
-			response = agentResponseManager.getRMapAgent(URLEncoder.encode(TestConstants.SYSAGENT_ID,StandardCharsets.UTF_8.name()),RdfMediaType.APPLICATION_RDFXML);
+			response = agentResponseManager.getRMapAgent(TestConstants.SYSAGENT_ID,RdfMediaType.APPLICATION_RDFXML);
 		} catch (Exception e) {
 			e.printStackTrace();			
 			fail("Exception thrown " + e.getMessage());
@@ -154,7 +151,7 @@ public class AgentResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 			queryParams.add(Constants.FROM_PARAM, "20121201000000");
 			
 			response = agentResponseManager.getRMapAgentEvents(
-					URLEncoder.encode(TestConstants.SYSAGENT_ID,StandardCharsets.UTF_8.name()), 
+					TestConstants.SYSAGENT_ID,
 					NonRdfType.JSON, 
 					queryParams);
 		} catch (Exception e) {
@@ -189,7 +186,7 @@ public class AgentResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 			
 	    	//first test no discos    	
 			response = agentResponseManager.getRMapAgentDiSCOs(
-					URLEncoder.encode(TestConstants.SYSAGENT_ID,StandardCharsets.UTF_8.name()),
+					TestConstants.SYSAGENT_ID,
 					NonRdfType.JSON, 
 					queryParams);
 			
@@ -211,7 +208,7 @@ public class AgentResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 			rmapService.createDiSCO(rmapDisco2, requestEventDetails);
 					
 			response = agentResponseManager.getRMapAgentDiSCOs(
-					URLEncoder.encode(TestConstants.SYSAGENT_ID,StandardCharsets.UTF_8.name()),
+					TestConstants.SYSAGENT_ID,
 					NonRdfType.JSON, 
 					queryParams);
 

--- a/api/src/test/java/info/rmapproject/api/responsemgr/DiscoResponseManagerTestIT.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/DiscoResponseManagerTestIT.java
@@ -170,7 +170,7 @@ public class DiscoResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 		rmapService.createDiSCO(rmapDisco, requestEventDetails);
 	
 		try {
-			response = discoResponseManager.getRMapDiSCO(URLEncoder.encode(discoURI,StandardCharsets.UTF_8.name()),matchingType);
+			response = discoResponseManager.getRMapDiSCO(discoURI,matchingType);
 		} catch (Exception e) {
 			e.printStackTrace();			
 			fail("Exception thrown " + e.getMessage());
@@ -218,7 +218,7 @@ public class DiscoResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 	   		
 
 			//now check original DiSCO
-			response = discoResponseManager.getRMapDiSCO(encodedDiscoUri1,matchingType);
+			response = discoResponseManager.getRMapDiSCO(discoURI,matchingType);
 			String links1 = response.getLinks().toString();
 			
 			String successorAndLatestVersionLink = ">;rel=\"" + LinkRels.SUCCESSOR_VERSION 
@@ -239,7 +239,7 @@ public class DiscoResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 			assertNotNull(mementoDate);
 			
 			//check updated disco
-			response = discoResponseManager.getRMapDiSCO(encodedDiscoUri2,matchingType);
+			response = discoResponseManager.getRMapDiSCO(discoURI2,matchingType);
 					
 			assertNotNull(response);
 			String body = response.getEntity().toString();
@@ -290,8 +290,7 @@ public class DiscoResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
     	
 		try {
 			//now get the latest using the first DiSCO URI
-			String encodedUriV1 = URLEncoder.encode(discoURIV1, StandardCharsets.UTF_8.name());
-			response = discoResponseManager.getLatestRMapDiSCOVersion(encodedUriV1,null);
+			response = discoResponseManager.getLatestRMapDiSCOVersion(discoURIV1,null);
 		} catch (Exception e) {
 			e.printStackTrace();			
 			fail("Exception thrown " + e.getMessage());
@@ -322,8 +321,7 @@ public class DiscoResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 		boolean correctErrorThrown = false;
    		
 		try {
-			String encodedUri = URLEncoder.encode(discoURI, StandardCharsets.UTF_8.name());
-			response = discoResponseManager.getRMapDiSCO(encodedUri,matchingType);
+			response = discoResponseManager.getRMapDiSCO(discoURI,matchingType);
 		} catch (RMapApiException e) {
 			assertEquals(e.getErrorCode(), ErrorCode.ER_DISCO_OBJECT_NOT_FOUND);
 			correctErrorThrown=true;
@@ -437,7 +435,7 @@ public class DiscoResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 		String encodedDiscoUriV2 = URLEncoder.encode(discoURIV2, "UTF-8");
    		
 		//now check original DiSCO
-		response = discoResponseManager.getRMapDiSCOTimemap(encodedDiscoUriV1);
+		response = discoResponseManager.getRMapDiSCOTimemap(discoURIV1);
 		String responseBody = response.getEntity().toString();
 		assertTrue(responseBody.contains(encodedDiscoUriV1));
 		assertTrue(responseBody.contains(encodedDiscoUriV2));
@@ -511,7 +509,7 @@ public class DiscoResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 		String sdLaterThanLast = HttpHeaderDateUtils.convertDateToString(dAfterLast);
 		String sdBetweenVersions = HttpHeaderDateUtils.convertDateToString(dBetweenVersions);
 								
-		Response response1 = discoResponseManager.getLatestRMapDiSCOVersion(encodedDiscoUriV1, sdEarlierThanFirst);
+		Response response1 = discoResponseManager.getLatestRMapDiSCOVersion(discoURIV1, sdEarlierThanFirst);
 		URI location1 = response1.getLocation();
 		//location should equal first:
 		assertTrue(location1.toString().contains(encodedDiscoUriV1));
@@ -522,19 +520,19 @@ public class DiscoResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 		assertTrue(links1.contains(encodedDiscoUriV1 + "/timemap>;rel=\"" + LinkRels.TIMEMAP + "\""));
 		assertTrue(links1.contains(encodedDiscoUriV1 + "/latest>;rel=\"" + LinkRels.ORIGINAL + " " + LinkRels.TIMEGATE + "\""));
 		
-		Response response2 = discoResponseManager.getLatestRMapDiSCOVersion(encodedDiscoUriV1, sdLaterThanLast);
+		Response response2 = discoResponseManager.getLatestRMapDiSCOVersion(discoURIV1, sdLaterThanLast);
 		URI location2 = response2.getLocation();
 		//location should equal last
 		assertTrue(location2.toString().contains(encodedDiscoUriV3));
 		assertEquals(302, response2.getStatus());
 
-		Response response3 = discoResponseManager.getLatestRMapDiSCOVersion(encodedDiscoUriV1, sdBetweenVersions);
+		Response response3 = discoResponseManager.getLatestRMapDiSCOVersion(discoURIV1, sdBetweenVersions);
 		URI location3 = response3.getLocation();
 		//location should equal second to last
 		assertTrue(location3.toString().contains(encodedDiscoUriV2));
 		assertEquals(302, response3.getStatus());
 		
-		Response response4 = discoResponseManager.getLatestRMapDiSCOVersion(encodedDiscoUriV1, null);
+		Response response4 = discoResponseManager.getLatestRMapDiSCOVersion(discoURIV1, null);
 		URI location4 = response4.getLocation();
 		//location should equal second to last
 		assertTrue(location4.toString().contains(encodedDiscoUriV3));

--- a/api/src/test/java/info/rmapproject/api/responsemgr/EventResponseManagerTestIT.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/EventResponseManagerTestIT.java
@@ -24,8 +24,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.net.URLEncoder;
-
 import javax.ws.rs.core.Response;
 
 import org.junit.Before;
@@ -128,7 +126,7 @@ public class EventResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 			
 			//getRMapStatement
 			Response response = null;
-			response = eventResponseManager.getRMapEvent(URLEncoder.encode(sEventUri, "UTF-8"),RdfMediaType.APPLICATION_RDFXML);
+			response = eventResponseManager.getRMapEvent(sEventUri,RdfMediaType.APPLICATION_RDFXML);
 			//response = responseManager.getRMapEvent("ark%3A%2F27927%2Ftf9yhn14ef","RDFXML");
 	
 			assertNotNull(response);
@@ -167,19 +165,19 @@ public class EventResponseManagerTestIT extends ApiDataCreationTestAbstractIT {
 			//getRMapStatement
 			Response response = null;
 			
-			response = eventResponseManager.getRMapEventRelatedObjs(URLEncoder.encode(sEventUri, "UTF-8"), RMapObjectType.OBJECT, NonRdfType.JSON);
+			response = eventResponseManager.getRMapEventRelatedObjs(sEventUri, RMapObjectType.OBJECT, NonRdfType.JSON);
 			assertNotNull(response);
 			String body = response.getEntity().toString();
 			assertTrue(body.contains(discoIri.toString()));
 			assertEquals(200, response.getStatus());
 
-			response = eventResponseManager.getRMapEventRelatedObjs(URLEncoder.encode(sEventUri, "UTF-8"), RMapObjectType.DISCO, NonRdfType.JSON);
+			response = eventResponseManager.getRMapEventRelatedObjs(sEventUri, RMapObjectType.DISCO, NonRdfType.JSON);
 			assertNotNull(response);
 			body = response.getEntity().toString();
 			assertTrue(body.contains(discoIri.toString()));
 			assertEquals(200, response.getStatus());
 			
-			response = eventResponseManager.getRMapEventRelatedObjs(URLEncoder.encode(sEventUri, "UTF-8"), RMapObjectType.AGENT, NonRdfType.JSON);
+			response = eventResponseManager.getRMapEventRelatedObjs(sEventUri, RMapObjectType.AGENT, NonRdfType.JSON);
 			assertNotNull(response);
 			body = response.getEntity().toString();
 			assertTrue(body.contains("[]"));

--- a/api/src/test/java/info/rmapproject/api/responsemgr/ResourceResponseManagerTestIT.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/ResourceResponseManagerTestIT.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.net.URI;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -237,11 +236,10 @@ public class ResourceResponseManagerTestIT extends ApiDataCreationTestAbstractIT
 	        assertNotNull(discoURI);
 			rmapService.createDiSCO(rmapDisco,requestEventDetails);
 						
-			String testDiscoDoi = URLEncoder.encode(TestConstants.TEST_DISCO_DOI,"UTF-8");
 			MultivaluedMap<String, String> params = new MultivaluedHashMap<String, String>();
 			params.add(Constants.PAGE_PARAM, "1");
 			params.add(Constants.FROM_PARAM, "20121201000000");
-			response = resourceResponseManager.getRMapResourceTriples(testDiscoDoi, RdfMediaType.APPLICATION_RDFXML, params);
+			response = resourceResponseManager.getRMapResourceTriples(TestConstants.TEST_DISCO_DOI, RdfMediaType.APPLICATION_RDFXML, params);
 
 			assertNotNull(response);
 			String body = response.getEntity().toString();
@@ -267,13 +265,11 @@ public class ResourceResponseManagerTestIT extends ApiDataCreationTestAbstractIT
 			String discoURI = rmapDisco.getId().toString();
 	        assertNotNull(discoURI);
 			rmapService.createDiSCO(rmapDisco,requestEventDetails);
-			
-			String resourceUri = URLEncoder.encode(discoURI, StandardCharsets.UTF_8.name());
-			
+						
 			MultivaluedMap<String, String> params = new MultivaluedHashMap<String, String>();
 			params.add(Constants.LIMIT_PARAM, "2");
 						
-			response = resourceResponseManager.getRMapResourceTriples(resourceUri, RdfMediaType.APPLICATION_RDFXML, params);
+			response = resourceResponseManager.getRMapResourceTriples(discoURI, RdfMediaType.APPLICATION_RDFXML, params);
 
 			assertNotNull(response);
 			String body = response.getEntity().toString();
@@ -290,7 +286,7 @@ public class ResourceResponseManagerTestIT extends ApiDataCreationTestAbstractIT
 			params.add(Constants.PAGE_PARAM, "1");	
 			params.add(Constants.UNTIL_PARAM, untildate);
 
-			response = resourceResponseManager.getRMapResourceTriples(resourceUri, RdfMediaType.APPLICATION_RDFXML, params);
+			response = resourceResponseManager.getRMapResourceTriples(discoURI, RdfMediaType.APPLICATION_RDFXML, params);
 			assertEquals(200,response.getStatus());
 			body = response.getEntity().toString();
 			int numMatches = StringUtils.countMatches(body, "xmlns=");

--- a/api/src/test/java/info/rmapproject/api/service/ResourceApiServiceTestIT.java
+++ b/api/src/test/java/info/rmapproject/api/service/ResourceApiServiceTestIT.java
@@ -26,8 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,7 +65,6 @@ public class ResourceApiServiceTestIT extends ApiDataCreationTestAbstractIT {
 		assertNotNull(discoURI);
 		rmapService.createDiSCO(rmapDisco,requestEventDetails);
 
-		String resourceUri = URLEncoder.encode(discoURI, StandardCharsets.UTF_8.name());
 		HttpHeaders httpheaders = mock(HttpHeaders.class);
 		UriInfo uriInfo = mock(UriInfo.class);
 
@@ -80,7 +77,7 @@ public class ResourceApiServiceTestIT extends ApiDataCreationTestAbstractIT {
 		when (uriInfo.getQueryParameters()).thenReturn(params);
 		when (httpheaders.getAcceptableMediaTypes()).thenReturn(mediatypes);
 
-		response = resourceApiService.apiGetRMapResourceTriples(httpheaders, resourceUri, uriInfo);
+		response = resourceApiService.apiGetRMapResourceTriples(httpheaders, discoURI, uriInfo);
 
 		assertNotNull(response);
 		String body = response.getEntity().toString();
@@ -97,7 +94,7 @@ public class ResourceApiServiceTestIT extends ApiDataCreationTestAbstractIT {
 		params.add(Constants.PAGE_PARAM, "1");
 		params.add(Constants.UNTIL_PARAM, untildate);
 
-		response = resourceApiService.apiGetRMapResourceTriples(httpheaders, resourceUri, uriInfo);
+		response = resourceApiService.apiGetRMapResourceTriples(httpheaders, discoURI, uriInfo);
 
 		assertEquals(200,response.getStatus());
 		body = response.getEntity().toString();

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/AgentDisplayController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/AgentDisplayController.java
@@ -20,7 +20,6 @@
 package info.rmapproject.webapp.controllers;
 
 import java.net.URI;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 
 import org.slf4j.Logger;
@@ -84,9 +83,6 @@ public class AgentDisplayController {
 	@RequestMapping(value="/agents/{uri}", method = RequestMethod.GET)
 	public String agent(@PathVariable(value="uri") String agentUri, Model model) throws Exception {
 		LOG.info("Agent requested: {}", agentUri);	
-
-		agentUri = URLDecoder.decode(agentUri, "UTF-8");
-		
 		AgentDTO agentDTO = dataDisplayService.getAgentDTO(agentUri);
 	    model.addAttribute("AGENT", agentDTO);	    
 	    model.addAttribute("RESOURCEURI", agentDTO.getUri());
@@ -121,8 +117,6 @@ public class AgentDisplayController {
 	public String agentDataVisual(@PathVariable(value="uri") String agentUri, Model model) throws Exception {
 		LOG.info("Agent requested: {}", agentUri);	
 
-		agentUri = URLDecoder.decode(agentUri, "UTF-8");
-		
 		AgentDTO agentDTO = dataDisplayService.getAgentDTO(agentUri);
 	    model.addAttribute("AGENT", agentDTO);	    
 	    model.addAttribute("RESOURCEURI", agentDTO.getUri());
@@ -143,8 +137,6 @@ public class AgentDisplayController {
 	public String agentDataWidget(@PathVariable(value="uri") String agentUri, Model model) throws Exception {
 		LOG.info("Agent requested: {}", agentUri);	
 
-		agentUri = URLDecoder.decode(agentUri, "UTF-8");
-		
 		AgentDTO agentDTO = dataDisplayService.getAgentDTO(agentUri);
 	    model.addAttribute("AGENT", agentDTO);	    
 	    model.addAttribute("RESOURCEURI", agentDTO.getUri());
@@ -165,8 +157,6 @@ public class AgentDisplayController {
 		LOG.info("Agent requested: {}", agentUri);	
 
 		try {
-			agentUri = URLDecoder.decode(agentUri, "UTF-8");
-			
 			AgentDTO agentDTO = dataDisplayService.getAgentDTO(agentUri);
 		    model.addAttribute("AGENT", agentDTO);	    
 		    model.addAttribute("RESOURCEURI", agentDTO.getUri());
@@ -194,8 +184,6 @@ public class AgentDisplayController {
 			view=STANDARD_VIEW;
 		}
 		try {
-			agentUri = URLDecoder.decode(agentUri, "UTF-8");
-			
 			AgentDTO agentDTO = dataDisplayService.getAgentDTO(agentUri);
 			Graph agentGraph = dataDisplayService.getAgentGraph(agentDTO);
 	
@@ -227,8 +215,6 @@ public class AgentDisplayController {
 			offset=0;
 		}
 		try {
-			agentUri = URLDecoder.decode(agentUri, "UTF-8");
-			
 			RMapStatusFilter statusFilter = RMapStatusFilter.getStatusFromTerm(status);
 			statusFilter = (statusFilter==null) ? RMapStatusFilter.ACTIVE : statusFilter;	
 			RMapSearchParams params = paramsFactory.newInstance();

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/DiSCODataController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/DiSCODataController.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package info.rmapproject.webapp.controllers;
 
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.List;
 
@@ -78,8 +77,6 @@ public class DiSCODataController {
 	public String disco(@PathVariable(value="uri") String discoUri, Model model) throws Exception {
 		LOG.info("DiSCO requested: {}", discoUri);
 
-		discoUri = URLDecoder.decode(discoUri, "UTF-8");
-
 		DiSCODTO discoDTO = dataDisplayService.getDiSCODTO(discoUri);
 	    
 		model.addAttribute("DISCO",discoDTO);	    
@@ -113,8 +110,6 @@ public class DiSCODataController {
 	@RequestMapping(value="/discos/{uri}/visual", method = RequestMethod.GET)
 	public String discoGraphVisual(@PathVariable(value="uri") String discoUri,  Model model) throws Exception {
 		LOG.info("DiSCO visualization requested: {}", discoUri);
-
-		discoUri = URLDecoder.decode(discoUri, "UTF-8");
 		
 		DiSCODTO discoDTO = dataDisplayService.getDiSCODTO(discoUri);
 	    
@@ -135,8 +130,6 @@ public class DiSCODataController {
 	@RequestMapping(value="/discos/{uri}/widget", method = RequestMethod.GET)
 	public String discoGraphWidget(@PathVariable(value="uri") String discoUri, Model model) throws Exception {
 		LOG.info("DiSCO visualization requested: {}", discoUri);
-
-		discoUri = URLDecoder.decode(discoUri, "UTF-8");
 		
 		DiSCODTO discoDTO = dataDisplayService.getDiSCODTO(discoUri);
 	    
@@ -163,8 +156,6 @@ public class DiSCODataController {
 			view=STANDARD_VIEW;
 		}
 		try {
-			discoUri = URLDecoder.decode(discoUri, "UTF-8");
-			
 			DiSCODTO discoDTO = dataDisplayService.getDiSCODTO(discoUri);
 		    
 			model.addAttribute("DISCO", discoDTO);	
@@ -198,8 +189,6 @@ public class DiSCODataController {
 			view=STANDARD_VIEW;
 		}
 		try {
-			discoUri = URLDecoder.decode(discoUri, "UTF-8");
-			
 			DiSCODTO discoDTO = dataDisplayService.getDiSCODTO(discoUri);
 		    
 			model.addAttribute("DISCO", discoDTO);	

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/EventDisplayController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/EventDisplayController.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package info.rmapproject.webapp.controllers;
 
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 
 import org.slf4j.Logger;
@@ -67,9 +66,6 @@ public class EventDisplayController {
 	@RequestMapping(value="/events/{uri}", method = RequestMethod.GET)
 	public String event(@PathVariable(value="uri") String eventUri, Model model) throws Exception {
 		LOG.info("Event requested {}", eventUri);
-
-		eventUri = URLDecoder.decode(eventUri, "UTF-8");
-		
 		EventDTO eventDTO = dataDisplayService.getEventDTO(eventUri);
 		model.addAttribute("EVENT", eventDTO);
 	    model.addAttribute("RESOURCEURI", eventDTO.getUri());

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/ResourceDisplayController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/ResourceDisplayController.java
@@ -20,7 +20,6 @@
 package info.rmapproject.webapp.controllers;
 
 import java.net.URI;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.List;
 
@@ -101,7 +100,6 @@ public class ResourceDisplayController {
 		LOG.info("Resource requested {}", sResourceUri);
 		
 		if (resview == null) {resview = 0;}
-		sResourceUri = URLDecoder.decode(sResourceUri, "UTF-8");
 	
 		if (resview==0) {
 			String rmapType = dataDisplayService.getRMapTypeDisplayName(new URI(sResourceUri));
@@ -169,13 +167,11 @@ public class ResourceDisplayController {
 				Model model) throws Exception {
 		LOG.info("Resource requested {}", reqUri);
 		
-		String decodedUri = URLDecoder.decode(reqUri, "UTF-8");
-	
 		//by default the system will redirect to the object type 
 		//e.g. a disco uri will redirect to DiSCO view.
 		if (resview == null) {resview = 0;}
 		if (resview==0) {
-			String rmapType = dataDisplayService.getRMapTypeDisplayName(new URI(decodedUri));
+			String rmapType = dataDisplayService.getRMapTypeDisplayName(new URI(reqUri));
 			if (rmapType.length()>0){
 				return "redirect:/" + rmapType.toLowerCase() + "s/" + reqUri + "/visual";
 			}
@@ -206,23 +202,21 @@ public class ResourceDisplayController {
 				Model model) throws Exception {
 		LOG.info("Resource requested {}", reqUri);
 
-		String decodedUri = URLDecoder.decode(reqUri, "UTF-8");
-		
 		//by default the system will redirect to the object type 
 		//e.g. a disco uri will redirect to DiSCO view.
 		if (resview == null) {resview = 0;}
 		if (resview==0) {
-			String rmapType = dataDisplayService.getRMapTypeDisplayName(new URI(decodedUri));
+			String rmapType = dataDisplayService.getRMapTypeDisplayName(new URI(reqUri));
 			if (rmapType.length()>0){
 				return "redirect:/" + rmapType.toLowerCase() + "s/" + reqUri + "/widget";
 			}
 		}    	
 
-		model.addAttribute("RESOURCEURI", decodedUri);
+		model.addAttribute("RESOURCEURI", reqUri);
 		model.addAttribute("status", status);
 				
 		RMapSearchParams params = generateSearchParams(status, offset);
-		ResultBatch<RMapTriple> triplebatch = dataDisplayService.getResourceBatch(decodedUri, params, PaginatorType.RESOURCE_GRAPH);
+		ResultBatch<RMapTriple> triplebatch = dataDisplayService.getResourceBatch(reqUri, params, PaginatorType.RESOURCE_GRAPH);
 		if (triplebatch==null || triplebatch.size()==0) {
 			return "resourcenotfoundembedded";
 		}
@@ -248,19 +242,18 @@ public class ResourceDisplayController {
 				@RequestParam(value="status", required=false) String status,
 				Model model) throws Exception {
 		LOG.info("Resource requested {}", reqUri);
-		String decodedUri = URLDecoder.decode(reqUri, "UTF-8");
 		try {
 
-			model.addAttribute("RESOURCEURI", decodedUri);
+			model.addAttribute("RESOURCEURI", reqUri);
 			model.addAttribute("status", status);
 			
 			RMapSearchParams params = generateSearchParams(status, offset);
-			ResultBatch<RMapTriple> triplebatch = dataDisplayService.getResourceBatch(decodedUri, params, PaginatorType.RESOURCE_TABLE);
+			ResultBatch<RMapTriple> triplebatch = dataDisplayService.getResourceBatch(reqUri, params, PaginatorType.RESOURCE_TABLE);
 			if (triplebatch==null || triplebatch.size()==0) {
 				return "resourcenotfoundembedded";
 			}
 			params.setOffset(0); //
-			ResourceDescription rd = dataDisplayService.getResourceTableData(decodedUri, triplebatch, params, true);
+			ResourceDescription rd = dataDisplayService.getResourceTableData(reqUri, triplebatch, params, true);
 			PageStatus pageStatus = dataDisplayService.getPageStatus(triplebatch, PaginatorType.RESOURCE_TABLE);
 	
 			model.addAttribute("TABLEDATA", rd);
@@ -292,13 +285,12 @@ public class ResourceDisplayController {
 		if (view==null || view.length()==0){
 			view = STANDARD_VIEW;
 		}
-		String decodedUri = URLDecoder.decode(reqUri, "UTF-8");
 		try {
-			model.addAttribute("RESOURCEURI", decodedUri);
+			model.addAttribute("RESOURCEURI", reqUri);
 			model.addAttribute("status", status);
 			RMapSearchParams params = generateSearchParams(status,offset);
 			
-			ResultBatch<RMapTriple> triplebatch = dataDisplayService.getResourceBatch(decodedUri, params, PaginatorType.RESOURCE_GRAPH);
+			ResultBatch<RMapTriple> triplebatch = dataDisplayService.getResourceBatch(reqUri, params, PaginatorType.RESOURCE_GRAPH);
 			if (triplebatch==null || triplebatch.size()==0) {
 				return "resourcenotfoundembedded";
 			}
@@ -330,14 +322,12 @@ public class ResourceDisplayController {
 				Model model) throws Exception {
 		LOG.info("Resource requested {}", reqUri);
 		try {
-			String decodedUri = URLDecoder.decode(reqUri, "UTF-8");
-			
 			RMapSearchParams params = generateSearchParams(status, offset);
 
-			ResultBatch<URI> resourceDiscos = dataDisplayService.getResourceRelatedDiSCOs(decodedUri, params);
+			ResultBatch<URI> resourceDiscos = dataDisplayService.getResourceRelatedDiSCOs(reqUri, params);
 		    PageStatus resDiscoPageStatus = dataDisplayService.getPageStatus(resourceDiscos, PaginatorType.RESOURCE_DISCOS);
 	
-		    model.addAttribute("RESOURCEURI", decodedUri);
+		    model.addAttribute("RESOURCEURI", reqUri);
 		    model.addAttribute("URILIST", resourceDiscos.getResultList());
 		    model.addAttribute("PAGINATOR", resDiscoPageStatus);
 	
@@ -371,8 +361,6 @@ public class ResourceDisplayController {
 			view=STANDARD_VIEW;
 		}
 		try {
-			resourceUri = URLDecoder.decode(resourceUri, "UTF-8");
-			
 			RMapSearchParams params = generateSearchParams(status,offset);
 			ResultBatch<RMapTriple> triplebatch = dataDisplayService.getResourceLiterals(resourceUri, params);
 			ResourceDescription resourceDescription = dataDisplayService.getResourceTableData(resourceUri, triplebatch, params, true);
@@ -416,9 +404,6 @@ public class ResourceDisplayController {
 		}
 		
 		try {
-			resourceUri = URLDecoder.decode(resourceUri, "UTF-8");
-			contextUri = URLDecoder.decode(contextUri, "UTF-8");
-
 			RMapSearchParams params = generateSearchParams(RMapStatusFilter.ALL, offset);
 			
 			ResultBatch<RMapTriple> triplebatch = dataDisplayService.getResourceLiteralsInContext(resourceUri, contextUri, params);

--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/SearchController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/SearchController.java
@@ -19,8 +19,6 @@
  *******************************************************************************/
 package info.rmapproject.webapp.controllers;
 
-import java.net.URLDecoder;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,7 +93,6 @@ public class SearchController {
 		}
 		Integer INCREMENT = 20;
 		Pageable pageable = PageRequest.of(page, INCREMENT);
-		search = URLDecoder.decode(search,"UTF-8");
 		search = search.trim();
 		search = search.replace("\"", ""); //remove quotes
 		search = search.replaceAll("( )+", " "); //remove extra spaces

--- a/webapp/src/main/java/info/rmapproject/webapp/service/SearchServiceSolr.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/service/SearchServiceSolr.java
@@ -122,6 +122,7 @@ public class SearchServiceSolr implements SearchService {
 							String label = snippet.substring(snippet.lastIndexOf(IndexUtils.HL_POSTFIX)+IndexUtils.HL_POSTFIX.length()+1);
 							//remove highlighted part, trim and remove quotes
 							label = label.trim().substring(1, label.length()-4);
+							label = label.replace("\\\"", "\"");
 							labels.add(label);	
 						}
 					}

--- a/webapp/src/main/webapp/includes/stylesheets/layout.css
+++ b/webapp/src/main/webapp/includes/stylesheets/layout.css
@@ -458,7 +458,6 @@ input[readonly]{background-color:#f0f0f0;}
 
 .navlinks {
 	display:inline-block;
-	text-align:center;
 	width:100%;
 	-webkit-user-select: none;  
 	-moz-user-select: none;    

--- a/webapp/src/test/java/info/rmapproject/webapp/controllers/ResourceDisplayControllerTestIT.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/controllers/ResourceDisplayControllerTestIT.java
@@ -85,6 +85,8 @@ public class ResourceDisplayControllerTestIT extends WebDataRetrievalTestAbstrac
     
     /**
      * Check invalid resource page should still return resources page, page display should handle empty
+     * Note: due to a glitch with encoding/decoding path variables in mockmvc, cannot depend on auto-decoding
+     * that is usual for PathVariable. So URI param is not encoded.
      * @throws Exception
      */
     @Test
@@ -95,7 +97,7 @@ public class ResourceDisplayControllerTestIT extends WebDataRetrievalTestAbstrac
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
 		rmapService.createDiSCO(disco, reqEventDetails);
-	    mockMvc.perform(get("/resources/fakefake%3Auri"))
+	    mockMvc.perform(get("/resources/{uri}","fakefake:uri"))
 	        	.andExpect(view().name("resources")); 
 
 		verify(dataDisplayService)
@@ -105,22 +107,20 @@ public class ResourceDisplayControllerTestIT extends WebDataRetrievalTestAbstrac
 
     /**
      * Check valid resource uri retrieves resource view
+     * Note: due to a problem with encoding/decoding path variables in mockmvc, cannot depend on auto-decoding
+     * that is usual for PathVariable, so URI is not encoded with URI queryparam
      * @throws Exception
      */
     @Test
-    public void testResourcePath() throws Exception {
+    public void testResourcePathRedirect() throws Exception {
     	doReturn("fakelabel").when(dataDisplayService).getResourceLabel(any(), any());
 
 		ORMapDiSCO disco = getRMapDiSCOObj(TestFile.DISCOB_V1_XML);
 		String discoUri = disco.getId().toString();
         assertNotNull(discoUri);
 		rmapService.createDiSCO(disco, reqEventDetails);
-        mockMvc.perform(get("/resources/ark%3A%2F27927%2F12121212"))
-        	.andExpect(view().name("resources"));     
-
-        	verify(dataDisplayService)
-			.getRMapTypeDisplayName(resourceUriCaptor.capture());
-		assertEquals(new URI("ark:/27927/12121212"),resourceUriCaptor.getValue());
+        mockMvc.perform(get("/resources?uri={uri}","ark:/27927/12121212"))
+        	.andExpect(view().name("redirect:/resources/ark%3A%2F27927%2F12121212"));     
         
     }
     

--- a/webapp/src/test/java/info/rmapproject/webapp/controllers/SearchControllerTestIT.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/controllers/SearchControllerTestIT.java
@@ -135,7 +135,7 @@ public class SearchControllerTestIT extends WebTestAbstractIT {
      */
     @Test
     public void searchDiscosWithUmlautAndSharpS() throws Exception {    	
-    	mockMvc.perform(get("/searchresults?search=Jörg%20Groß"))
+    	mockMvc.perform(get("/searchresults").param("search", "Jörg Groß"))
    	        	.andExpect(view().name("searchresults")); 
 
 		verify(searchService)


### PR DESCRIPTION
Closes #230
When a Resource URI has special characters encoded into the querystring, they were being double decoded in RMap and this was causing matches not to be found for these URLs. The decoding already happens by default when the Path* annotations are used. This removes the additional http decoding which was causing problems when using the encoded parameter URLs.
It also replaces escaped quotes with regular quotes in results that are pulled from Solr when searching for labels.