### PR TITLE
Final GUI text changes for release

### DIFF
--- a/webapp/src/main/java/info/rmapproject/webapp/controllers/HomeController.java
+++ b/webapp/src/main/java/info/rmapproject/webapp/controllers/HomeController.java
@@ -58,10 +58,26 @@ public class HomeController {
 	public String about(Model model) {
 		return "about";
 	}
-	
+
+    /**
+     * GETs the Glossary page
+     *
+     * @param model the Spring model
+     * @return the about page
+     */
 	@RequestMapping(value={"/about/glossary"}, method=RequestMethod.GET)
 	public String glossary(Model model) {
 		return "glossary";
 	}	
-	
+
+    /**
+     * GETs the Terms of Use page
+     *
+     * @param model the Spring model
+     * @return the about page
+     */
+    @RequestMapping(value={"/about/terms"}, method=RequestMethod.GET)
+    public String terms(Model model) {
+        return "terms";
+    }   
 }

--- a/webapp/src/main/webapp/WEB-INF/tags/headerFull.tag
+++ b/webapp/src/main/webapp/WEB-INF/tags/headerFull.tag
@@ -38,6 +38,7 @@
 				<ul class="dropdown-menu">
 					<li><a href="<c:url value='/about'/>">About RMap</a></li>	
 					<li><a href="<c:url value='/about/glossary'/>">Glossary</a></li>	
+					<li><a href="<c:url value='/about/terms'/>">Terms of Use</a></li>	
 				</ul>
 			</li>
 			

--- a/webapp/src/main/webapp/WEB-INF/views/about.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/about.jsp
@@ -11,6 +11,7 @@
 		<a href="#using-ids">Using ORCID IDs, DOIs and other PIDs</a>&nbsp;&nbsp;|&nbsp;&nbsp;
 		<a href="#why-duplicates">Why are there duplicates in the visualization?</a>&nbsp;&nbsp;|&nbsp;&nbsp;
 		<a href="#funding">Funding</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+		<a href="#ieee-discos">IEEE DiSCOs</a>&nbsp;&nbsp;|&nbsp;&nbsp;
 		<a href="#additional-info">Additional information</a>
 	</p>
 	
@@ -86,7 +87,14 @@
 	This instance of RMap is managed by 
 	<a href="${SITEPROPS.getInstitutionUrl()}" target="_blank">${SITEPROPS.getInstitutionName()}</a>.
 	</p>
-	
+			
+	<div id="ieee-discos"></div>
+	<h2>IEEE DiSCOs</h2>
+	<p>The <a href="https://rmap-hub.org">instance of RMap</a> hosted by the <a href="https://library.jhu.edu/" target="_blank">Sheridan Libraries at Johns Hopkins University</a> was 
+	initially populated using over 680,000 DiSCOs provided by the <a href="https://www.ieee.org" target="_blank">Institute of Electrical and Electronics Engineers</a> (IEEE). 
+	These were created using IEEE’s article database. All of them include basic article metadata such as title, journal, and author names, but many also contain additional relationships 
+	such as citation links, ORCID IDs, and dataset links as available.</p>
+		
 	<div id="additional-info"></div>
 	<h2>Additional information</h2>
 	<p>For additional information about RMap, visit the <a href="http://rmap-project.info/rmap/?page_id=98" target="_blank">RMap Project website</a>. 

--- a/webapp/src/main/webapp/WEB-INF/views/error.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/error.jsp
@@ -6,7 +6,7 @@
 	<h1>System Error</h1>
 	
 	<p>A system error occurred. If you continue to experience problems, please report this to an administrator for further assistance.</p>
-	<p><a href="<c:url value='/search'/>">Goto Search page</a></p>
+	<p><a href="<c:url value='/home'/>">Go to Home page</a></p>
 	
 	<br/>
 	<br/>

--- a/webapp/src/main/webapp/WEB-INF/views/home.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/home.jsp
@@ -19,8 +19,9 @@
 			<input type="hidden" name="status" value="active"/>
 			<input type="submit" value="Search" style="margin-top:3px;">
 			<p style="font-size: 85%;">Example search terms: 
-			<a href="<c:url value='/searchresults?search=NASA&status=active'/>">"NASA"</a>, 
-			<a href="<c:url value='/searchresults?search=https://doi.org/10.7265/n59p2ztg&status=active'/>">"https://doi.org/10.7265/n59p2ztg"</a>
+			<a href="<c:url value='/searchresults?search=IEEE&status=active'/>">"IEEE"</a>, 
+			<a href="<c:url value='/searchresults?search=climate&status=active'/>">"climate"</a>, 
+			<a href="<c:url value='/searchresults?search=https://doi.org/10.1109/jlt.2006.888256&status=active'/>">"https://doi.org/10.1109/jlt.2006.888256"</a>
 			</p>
 			<br>
 			<div class="containframe">

--- a/webapp/src/main/webapp/WEB-INF/views/objectnotfound.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/objectnotfound.jsp
@@ -7,7 +7,7 @@
 	<h1>Resource not found</h1>
 	
 	<p>The resource requested could not be found in the RMap database.</p>
-	<p><a href="<c:url value='/search'/>">Goto Search page</a></p>
+	<p><a href="<c:url value='/home'/>">Go to Home page</a></p>
 	
 	<br/>
 	<br/>

--- a/webapp/src/main/webapp/WEB-INF/views/terms.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/terms.jsp
@@ -1,0 +1,32 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib prefix="tl" tagdir="/WEB-INF/tags" %>
+
+<tl:pageStartStandard user="${user}" pageTitle="Terms of Use"/>
+	<h1>Terms of Use</h1>
+	
+	<p>All <a href="<c:url value='/about/glossary#RMapDiSCO'/>">DiSCOs</a> created in RMap, and their related provenance information  
+	(<a href="<c:url value='/about/glossary#RMapEvent'/>">Events</a>, <a href="<c:url value='/about/glossary#RMapAgent'/>">Agents</a>), 
+	will automatically become publicly accessible through the RMap website and API.</p>
+	
+	<p>
+		This instance of RMap is a beta service. While basic backups are performed, and the eventual goal is to maintain all data for the 
+		subsequent production version, full mechanisms for recovery and preservation are not yet in place. Therefore, RMap currently provides 
+		no guarantee for the long term persistence and preservation of users' data. In cases of software and hardware failures, users' data 
+		and the resulting RMap DiSCOs may be unrecoverable. 
+	</p>
+	
+	<h2>Disclaimer</h2>
+	<p>
+		Users acknowledge that RMap is in beta testing phase and no warranty whatsoever is offered with respect to its installation or operation. 
+		To the extent not prohibited by law, under no circumstances shall JHU be liable with respect to RMap for special, indirect, incidental, 
+		or consequential damages, including without limitation, damages resulting from delay of delivery or from loss of profits, data, business or 
+		goodwill, on any theory of liability, whether arising under tort (including negligence), contact or otherwise, whether or not JHU has been 
+		advised or is aware of the possibility of such damages. If, notwithstanding any other provisions of this agreement, JHU is found to be liable 
+		to you for any damage or loss that arises out of or is in any way connected to your use of the service, JHU's entire liability for direct damages 
+		under this agreement shall be limited to five dollars ($5.00).
+	</p>
+	<br/>
+	
+	
+<tl:pageEndStandard/>


### PR DESCRIPTION
- Added terms of use page. Needs additional work, but for now includes formal disclaimer, and notice about the public nature of the data and the absence of preservation during beta phase.
- Added information about IEEE data load to About page
- Added IEEE as a sample search on the home page, and changed doi example search to an IEEE doi that is in the initial data load
- Fixed a link to a non-existent search page on the error pages.