### PR TITLE
Changes to avoid unidentified contexts getting into getStatements

### DIFF
--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapEventMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapEventMgr.java
@@ -298,6 +298,9 @@ public class ORMapEventMgr extends ORMapObjectMgr {
 			RMapEventType eventType = this.getEventType(eventId, ts);
 			RMapEventTargetType targetType = this.getEventTargetType(eventId, ts);
 			
+            if (!this.isEventId(eventId, ts)) {
+                throw new RMapException ("Event ID not recognized")  ;                
+            }
 			switch (targetType){
 			case DISCO:
 				switch (eventType){
@@ -853,6 +856,7 @@ public class ORMapEventMgr extends ORMapObjectMgr {
 
 		Set<Statement> stmts = null;
 		Set<Statement> returnStmts = new HashSet<Statement>();
+
 		try {
 			stmts = ts.getStatements(null, eventPredicate, objectUri);
 			for (Statement stmt:stmts){
@@ -910,19 +914,22 @@ public class ORMapEventMgr extends ORMapObjectMgr {
 		IRI createdDisco = null;
 		Set<Statement> stmts = null;
 		try {
-			stmts = ts.getStatements(updateEventID, PROV.GENERATED, null, updateEventID);
+
+            if (this.isEventId(updateEventID, ts)) {
+                stmts = ts.getStatements(updateEventID, PROV.GENERATED, null, updateEventID);
+            }
 			if (stmts != null){
-					for (Statement stmt:stmts){
-						Value vObject = stmt.getObject();
-						if (vObject instanceof IRI){
-							IRI iri = (IRI)vObject;
-							if (this.isDiscoId(iri, ts)){
-								createdDisco = (IRI)vObject;
-								break;
-							}
+				for (Statement stmt:stmts){
+					Value vObject = stmt.getObject();
+					if (vObject instanceof IRI){
+						IRI iri = (IRI)vObject;
+						if (this.isDiscoId(iri, ts)){
+							createdDisco = (IRI)vObject;
+							break;
 						}
 					}
 				}
+			}
 		} catch (Exception e) {
 			throw new RMapException (e);
 		}

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapObjectMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapObjectMgr.java
@@ -158,12 +158,14 @@ public abstract class ORMapObjectMgr {
 	protected Set<Statement> getNamedGraph(IRI id, Rdf4jTriplestore ts) throws RMapObjectNotFoundException, RMapException {
 		Set<Statement> matchingTriples = null;
 		try {
-			matchingTriples = ts.getStatements(null, null, null, false, id);     
+            if (ts.getConnection().size(id)>0) {
+                matchingTriples = ts.getStatements(null, null, null, false, id);   
+            }
 		} catch (Exception e) {
 			throw new RMapException("Exception fetching triples matching named graph id "
 					+ id.stringValue(), e);
 		}
-		if (matchingTriples.isEmpty()){
+		if (matchingTriples==null || matchingTriples.isEmpty()){
 			throw new RMapObjectNotFoundException("could not find triples matching named graph id " + id.toString());
 		}
 		return matchingTriples;

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapResourceMgr.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapResourceMgr.java
@@ -439,7 +439,9 @@ public class ORMapResourceMgr extends ORMapObjectMgr {
 		}
 		Set<Statement> triples = null;
 		try {
-			triples = ts.getStatements(resourceIri, RDF.TYPE, null, contextIri);
+		    if (ts.getConnection().size(contextIri)>0) {
+		        triples = ts.getStatements(resourceIri, RDF.TYPE, null, contextIri);
+		    }
 		} catch (Exception e) {
 			throw new RMapException (e);
 		}	

--- a/core/src/main/java/info/rmapproject/core/rmapservice/impl/rdf4j/triplestore/Rdf4jTriplestore.java
+++ b/core/src/main/java/info/rmapproject/core/rmapservice/impl/rdf4j/triplestore/Rdf4jTriplestore.java
@@ -227,12 +227,16 @@ public abstract class Rdf4jTriplestore  {
 			resultset = getConnection().getStatements(subj, pred, obj, includeInferred);
 		}
 		else	{
-			resultset = getConnection().getStatements(subj, pred, obj, includeInferred, context);
+		    if (getConnection().size(context)>0) {
+		        resultset = getConnection().getStatements(subj, pred, obj, includeInferred, context);
+		    }
 		}
-		while (resultset.hasNext()) {
-			Statement stmt = resultset.next();
-			stmts.add(stmt);
-		}		
+		if (resultset!=null) {
+    		while (resultset.hasNext()) {
+    			Statement stmt = resultset.next();
+    			stmts.add(stmt);
+    		}	
+		}
 		return stmts;
 	}
 	


### PR DESCRIPTION
Closes issue #248

When a contextUri does not exist and it is used in rdf4j's triplestore.getStatements(sub,pred,obj,includeinf,context), it does not release the connection.  After the connections are used up, graphdb hangs. This is the same issue as in #123 and was replicated by repeatedly accessing a non existent URI on the /api/{discos|agent|event}/{uri} path.

I added code to check the contextUri is valid before calling getStatements() with the context param.

I manually tested on dev and can no longer replicate issue #248, but does need a series of integration tests - it's not clear at this point whether this is graphdb specific or related to the rdf4j library.