### PR TITLE
2 minor fixes: Fix link on deleted page, remove extra http decode

### DIFF
--- a/api/src/main/java/info/rmapproject/api/utils/PathUtils.java
+++ b/api/src/main/java/info/rmapproject/api/utils/PathUtils.java
@@ -255,9 +255,6 @@ public class PathUtils {
 	public String appendEncodedUriToURL(String baseURL, String objUri) throws RMapApiException {
 		String url = null;
 		try {
-			//may already been encoded, so let's decode first to make sure we aren't double encoding
-			objUri = URLDecoder.decode(objUri,"UTF-8");
-			//now encode!
 			url = baseURL + URLEncoder.encode(objUri,"UTF-8");
 		}
 		catch (Exception e)	{

--- a/webapp/src/main/webapp/WEB-INF/views/deleted.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/deleted.jsp
@@ -8,7 +8,7 @@
 	<h1>Resource Deleted</h1>
 	
 	<p>The requested resource has been deleted.</p>
-	<p><a href="<c:url value='/search'/>">Goto Search page</a></p>
+	<p><a href="<c:url value='/home'/>">Search for a different resource</a></p>
 	
 	<br/>
 	<br/>


### PR DESCRIPTION
Fixes two minor things:

#### Removes an extra httpdecode. 
This was missed during the clean up in PR #240. Double decoding can destroy links that should contain encoded parts. The scope of what this affects is very narrow - it affects response header links in the API when you are paginating!

Test:
1. Perform a GET like this:
`curl -v "https://test.rmap-hub.org/api/resources/https%3A%2F%2Frosetest.library.jhu.edu%2Faor2-test%2F%23aor%2FRCPD1266%2Fbinding%2520front%2520cover%2Fimage?limit=1&page=1"`
2. View the response headers, there is a link that ends with `page=2`. Copy the resource part of the link `https://test.rmap-hub.org/api/resources/{resource}?limit=1&page=2`.
3. Paste the encoded resource part of the URL into a decoder e.g. https://meyerweb.com/eric/tools/dencoder/
4. If it is working correctly, when you decode, it should show a link containing `binding%20front%20cover`, before this fix it would show `binding+front+cover` 

#### Fixes the link on the deleted page
Now points to `/home` instead of `/search`, which no longer exists. 

Test:
1. Go to the following link - it is a deleted resource: 
https://test.rmap-hub.org/app/discos/ark%3A%2F99999%2Ffk4cv5rd17
2. Click to do a new search, it should take you to the home page