### PR TITLE
Fix string compare in authentication interceptor

### DIFF
--- a/api/src/main/java/info/rmapproject/api/auth/AuthenticationInterceptor.java
+++ b/api/src/main/java/info/rmapproject/api/auth/AuthenticationInterceptor.java
@@ -82,7 +82,7 @@ public class AuthenticationInterceptor extends AbstractPhaseInterceptor<Message>
 	    	HttpServletRequest req = (HttpServletRequest) message.get("HTTP.REQUEST");
 	    	String method = req.getMethod();
 	    	
-	    	if (method!=HttpMethod.GET && method!=HttpMethod.OPTIONS && method!=HttpMethod.HEAD){
+	    	if (!method.equals(HttpMethod.GET) && !method.equals(HttpMethod.OPTIONS) && !method.equals(HttpMethod.HEAD)){
     	 
 		    	AuthorizationPolicy policy = apiUserService.getCurrentAuthPolicy();
 		    	String accessKey = policy.getUserName();


### PR DESCRIPTION
Wrong kind of equals used was causing OPTIONS and HEAD to require a key. Fortunately this seems to be the only symptom of the bad code. For some reason GET was fine without a key.

I have already tested this - it's fixed, and the code was clearly wrong before. 

If you wish to confirm, follow the instructions for running RMap locally:
https://github.com/rmap-project/rmap/blob/master/DEVELOPER.md#running-rmap
The following commands should return a link and allow header:
```
curl -i -X OPTIONS http://localhost:[portnum]/api/discos
curl -i -I HEAD http://localhost:[portnum]/api/discos
```
For the original behavior, see the live sites:
```
curl -i -X OPTIONS https://rmap-hub.org/api/discos
curl -i -I HEAD https://rmap-hub.org/api/discos
```