### PR TITLE
Update documentation links, 2 minor bug fixes

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,9 +8,9 @@ As the name suggests, this contains the core code for the RMap software. It defi
 ### auth
 *Core* functions support the creation of an RMap Agent, and each time you write to RMap a valid Agent URI is required.  The *core* module is not otherwise involved in authentication or user management. Instead, the web application and API handle the authorization and authentication of users. To do this they both use the *auth* component. This coordinates between the users that have logged in through the website, the API keys those users create, and the association of an RMap Agent. The *auth* module is supported by a small user database. 
 ### api
-The api module provides a REST API to expose the major functions of RMap.  These include functions to manage DiSCOs and retrieve triples that reference particular resource URIs.  The technical wiki contains a [full description of the API functions](https://rmap-project.atlassian.net/wiki/display/RMAPPS/API+Documentation).  Read functions are available without an API key. Write funtions require the user to login through the website and register for an API key. 
+The api module provides a REST API to expose the major functions of RMap.  These include functions to manage DiSCOs and retrieve triples that reference particular resource URIs.  The technical documentation contains a [full description of the API functions](https://github.com/rmap-project/rmap-documentation/api).  Read functions are available without an API key. Write funtions require the user to login through the website and register for an API key. 
 ### webapp
-The web application allows users to browse RMap Agents, DiSCOs, and Events in a visual and interactive way.  It also supports the configuration of RMap Agents and API keys to be used for write-access to the RMap API. A [live demo site](https://demo.rmap-hub.org/app) is available to try out.
+The web application allows users to browse RMap Agents, DiSCOs, and Events in a visual and interactive way.  It also supports the configuration of RMap Agents and API keys to be used for write-access to the RMap API. A [live demo site](https://test.rmap-hub.org/app) is available to try out.
 ### testdata
 The test data module contains RDF files for DiSCOs and Agents. This data is used to generate test data for the JUnit tests in the other modules.
 ### integration
@@ -30,7 +30,7 @@ RMap is a Maven-based project.  To build RMap from source, including creating ja
 mvn clean install
 ``` 
 This command will build each module (`core`, `auth`, `api`, etc.) in dependency order, and install the built artifacts (i.e. the resulting JAR and WAR files) into your local Maven repository (normally located at `~/.m2/repository`).
-The `war` files will be found in the `/target` folder of `webapp` and `api`. These can be installed per the [installation documentation](https://rmap-project.atlassian.net/wiki/display/RMAPPS/Installation).  If, however, you simply need to run a local instance of RMap for development purposes, see below for instructions on the [developer runtime](#developer-runtime)
+The `war` files will be found in the `/target` folder of `webapp` and `api`. These can be installed per the [installation documentation](https://github.com/rmap-project/rmap-documentation/installation).  If, however, you simply need to run a local instance of RMap for development purposes, see below for instructions on the [developer runtime](#developer-runtime)
 Note: the RMap integration tests require Docker. If you don't have Docker, you can skip the integration tests using the following:
 ```
 mvn clean install -DskipITs -Ddocker.skip -Dcargo.maven.skip

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The RMap Project is an Alfred P. Sloan Foundation-funded initiative undertaken b
 
 The RMap software allows users to create and manage these maps of relationships as RDF graphs in a format called RMap DiSCOs (Distributed Scholarly Compound Objects).  DiSCOs are named graphs consisting of a persistent identifier, a list of aggregated works ("ore:aggregates"), an optional list of additional assertions (which must form a connected graph with the aggregated works), and several other optional metadata fields.  The provenance of each DiSCO is captured as RMap Events, and each Event cites the RMap Agent responsible for triggering it.
 
-Further documentation and links about the RMap Project are available on the [RMap website](http://rmap-project.info/) and [technical wiki](https://rmap-project.atlassian.net).  A working instance of RMap, hosted by the [Sheridan Libraries at Johns Hopkins University](https://libraries.jhu.edu), is available at [https://rmap-hub.org](https://rmap-hub.org).
+Further documentation and links about the RMap Project are available on the [RMap website](http://rmap-project.info/) and in the [technical documentation](https://github.com/rmap-project/rmap-documentation).  A working instance of RMap, hosted by the [Sheridan Libraries at Johns Hopkins University](https://libraries.jhu.edu), is available at [https://rmap-hub.org](https://rmap-hub.org).
 
 # Downloading RMap
 The current version of RMap and supporting scripts can be [downloaded from the Github](https://github.com/rmap-project/rmap/releases). 

--- a/api/src/main/java/info/rmapproject/api/responsemgr/AgentResponseManager.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/AgentResponseManager.java
@@ -365,7 +365,7 @@ public class AgentResponseManager extends ResponseManager {
 						.type(HttpTypeMediator.getResponseNonRdfMediaType(returnType));		
 
 				//are we doing page links?
-				if (resultbatch.hasNext() || currPage>1) {
+				if (resultbatch.hasNext() || (currPage!=null && currPage>1)) {
 					String pageLinkTemplate =
 							queryParamHandler.getPageLinkTemplate(path, queryParams, params.getLimit());
 					Link[] pageLinks =

--- a/api/src/main/java/info/rmapproject/api/service/EventApiService.java
+++ b/api/src/main/java/info/rmapproject/api/service/EventApiService.java
@@ -172,7 +172,7 @@ public class EventApiService {
     @Produces({"application/json;charset=UTF-8;","text/plain;charset=UTF-8;"})
     public Response apiGetRMapEventDiSCOs(@Context HttpHeaders headers, @PathParam("eventUri") String eventUri) throws RMapApiException {
     	NonRdfType outputType = HttpTypeMediator.getNonRdfResponseType(headers);
-    	Response relatedDiscos = getEventResponseManager().getRMapEventRelatedObjs(eventUri, RMapObjectType.EVENT, outputType);
+    	Response relatedDiscos = getEventResponseManager().getRMapEventRelatedObjs(eventUri, RMapObjectType.DISCO, outputType);
 	    return relatedDiscos;
     }
 

--- a/api/src/main/resources/rmapapi.properties
+++ b/api/src/main/resources/rmapapi.properties
@@ -3,4 +3,4 @@
 rmapapi.path=https\://fake.rmap-hub.org/fake
 #rmapapi.documentationPath: this is the path provided in response headers to indicate the location
 #of RMap API documentation
-rmapapi.documentationPath=https\://rmap-project.atlassian.net/wiki/display/RMAPPS/API+Documentation
+rmapapi.documentationPath=https\://github.com/rmap-project/rmap-documentation

--- a/core/src/test/java/info/rmapproject/core/model/impl/rdf4j/ORMapDiscoTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/rdf4j/ORMapDiscoTest.java
@@ -100,7 +100,7 @@ public class ORMapDiscoTest extends CoreTestAbstract {
 	public void setUp() throws Exception {
 		vf = ORAdapter.getValueFactory();
 		r = vf.createIRI("http://rmap-info.org");	
-		r2 = vf.createIRI("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki");
+		r2 = vf.createIRI("https://github.com/rmap-project/rmap-documentation");
 		a = vf.createLiteral("a");
 		b = vf.createIRI("http://b.org");
 		c = vf.createIRI("http://c.org");
@@ -129,7 +129,7 @@ public class ORMapDiscoTest extends CoreTestAbstract {
 		try {
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 			RMapIri author = ORAdapter.rdf4jIri2RMapIri(creatorIRI);
 			ORMapDiSCO disco = new ORMapDiSCO(uri2Rdf4jIri(create("http://example.org/disco/1")), author, resourceList);
 			assertEquals(author.toString(),disco.getCreator().getStringValue());
@@ -259,7 +259,7 @@ public class ORMapDiscoTest extends CoreTestAbstract {
 		try {
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 			RMapIri author = ORAdapter.rdf4jIri2RMapIri(creatorIRI);
 			ORMapDiSCO disco = new ORMapDiSCO(uri2Rdf4jIri(create("http://example.org/disco/" + counter.getAndIncrement())), author, resourceList);
 			assertEquals(author.toString(),disco.getCreator().getStringValue());
@@ -289,7 +289,7 @@ public class ORMapDiscoTest extends CoreTestAbstract {
 		try {
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 			RMapIri author = ORAdapter.rdf4jIri2RMapIri(creatorIRI);
 			ORMapDiSCO disco = new ORMapDiSCO(uri2Rdf4jIri(create("http://example.org/disco/" + counter.getAndIncrement())), author, resourceList);
 			Literal desc = vf.createLiteral("this is a description");
@@ -316,7 +316,7 @@ public class ORMapDiscoTest extends CoreTestAbstract {
 		try {
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 			RMapIri author = ORAdapter.rdf4jIri2RMapIri(creatorIRI);
 			ORMapDiSCO disco = new ORMapDiSCO(uri2Rdf4jIri(create("http://example.org/disco/" + counter.getAndIncrement())), author, resourceList);
 			Statement stmt = disco.getTypeStatement();
@@ -340,7 +340,7 @@ public class ORMapDiscoTest extends CoreTestAbstract {
 		try {
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 			RMapIri author = ORAdapter.rdf4jIri2RMapIri(creatorIRI);
 			ORMapDiSCO disco = new ORMapDiSCO(uri2Rdf4jIri(create("http://example.org/disco/" + counter.getAndIncrement())), author, resourceList);
 			IRI context = disco.getDiscoContext();

--- a/core/src/test/java/info/rmapproject/core/model/impl/rdf4j/ORMapEventCreationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/rdf4j/ORMapEventCreationTest.java
@@ -91,7 +91,7 @@ public class ORMapEventCreationTest extends ORMapCommonEventTest {
 		    IRI creatorIRI = vf.createIRI("http://orcid.org/0000-0003-2069-1219");
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 			RMapIri associatedAgent = ORAdapter.rdf4jIri2RMapIri(creatorIRI);
 			ORMapDiSCO disco = new ORMapDiSCO(uri2Rdf4jIri(create("http://example.org/disco/1")), associatedAgent, resourceList);
 			// Make list of created objects

--- a/core/src/test/java/info/rmapproject/core/model/impl/rdf4j/ORMapEventDeletionTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/rdf4j/ORMapEventDeletionTest.java
@@ -160,7 +160,7 @@ public class ORMapEventDeletionTest extends ORMapCommonEventTest {
 			IRI creatorIRI = vf.createIRI("http://orcid.org/0000-0003-2069-1219");
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 			RMapIri associatedAgent = ORAdapter.rdf4jIri2RMapIri(creatorIRI);
 			
 			ORMapDiSCO disco = new ORMapDiSCO(uri2Rdf4jIri(create("http://example.org/disco/1")), associatedAgent, resourceList);

--- a/core/src/test/java/info/rmapproject/core/model/impl/rdf4j/ORMapEventDerivationTest.java
+++ b/core/src/test/java/info/rmapproject/core/model/impl/rdf4j/ORMapEventDerivationTest.java
@@ -111,7 +111,7 @@ public class ORMapEventDerivationTest extends ORMapCommonEventTest {
 		try {
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 		} catch (URISyntaxException e) {
 			e.printStackTrace();
 			fail("unable to create resources");
@@ -164,7 +164,7 @@ public class ORMapEventDerivationTest extends ORMapCommonEventTest {
 		try {
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 		} catch (URISyntaxException e) {
 			e.printStackTrace();
 			fail("unable to create resources");

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapObjectMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapObjectMgrTest.java
@@ -152,7 +152,7 @@ public class ORMapObjectMgrTest extends ORMapMgrTest {
 		    IRI creatorIRI = ORAdapter.getValueFactory().createIRI("http://orcid.org/0000-0003-2069-1219");
 			resourceList.add(new java.net.URI("http://rmap-info.org"));
 			resourceList.add(new java.net.URI
-					("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki"));
+					("https://github.com/rmap-project/rmap-documentation"));
 			RMapIri associatedAgent = ORAdapter.rdf4jIri2RMapIri(creatorIRI);
 			ORMapDiSCO disco = new ORMapDiSCO(ORAdapter.uri2Rdf4jIri(rmapIdService.createId()), associatedAgent, resourceList);
 			// Make list of created objects

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/rdf4j/OStatementsAdapterTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/rdf4j/OStatementsAdapterTest.java
@@ -131,7 +131,7 @@ public class OStatementsAdapterTest extends CoreTestAbstract {
 		ValueFactory vf = ORAdapter.getValueFactory();
 		
 		Resource agg1 = vf.createIRI("http://rmap-info.org");	
-		Resource agg2 = vf.createIRI("https://rmap-project.atlassian.net/wiki/display/RMAPPS/RMap+Wiki");
+		Resource agg2 = vf.createIRI("https://github.com/rmap-project/rmap-documentation");
 		
 		List<URI> aggregatedResources = new ArrayList<URI>();
 		aggregatedResources.add(new URI(agg1.toString()));

--- a/integration/src/test/java/info/rmapproject/integration/SmokeTestIT.java
+++ b/integration/src/test/java/info/rmapproject/integration/SmokeTestIT.java
@@ -42,7 +42,7 @@ public class SmokeTestIT extends BaseHttpIT {
      */
     @Test
     public void testApi200Ok() throws IOException {
-        String searchString = "https://rmap-project.atlassian.net/wiki/display/RMAPPS/API+Documentation";
+        String searchString = "https://github.com/rmap-project/rmap-documentation";
         URL url = new URL(apiBaseUrl, apiCtxPath + "/discos");
         Response res = http.newCall(new Request.Builder().get().url(url).build()).execute();
         ResponseBody body = res.body();

--- a/webapp/src/main/webapp/WEB-INF/views/about.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/about.jsp
@@ -49,7 +49,7 @@
 	Data submitted through the API must be formatted as valid RMap DiSCOs - a simple RDF model that can wrap around most RDF graphs with a few constraints: 
 	(1) the DiSCO has two required fields "rdf:type=DiSCO" and a list of "aggregated resources", and (2) the RDF graph must be fully connected to the 
 	aggregated resources listed.</p>
-	<p>For full documentation on the RMap data model and how to use the API to create DiSCOs please visit the <a href="https://rmap-project.atlassian.net/wiki/spaces/RMAPPS/overview">RMap Technical Wiki</a>. 
+	<p>For full documentation on the RMap data model and how to use the API to create DiSCOs please visit the <a href="https://github.com/rmap-project/rmap-documentation">RMap technical documentation</a>. 
 	Feel free to <a href="mailto:${SITEPROPS.getContactEmail()}">contact us</a> with any questions about obtaining API keys, or creating DiSCOs.
 	</p>
 	
@@ -57,8 +57,8 @@
 	<h2>Using ORCID IDs, DOIs, and other PIDs</h2>
 	<p>Where possible, it is recommended that the resources expressed in your DiSCOs are represented using unique persistent identifiers (PIDs) such as DOIs, ORCID IDs, 
 	ARK IDs, Handles, ISNIs etc. This is not a requirement, all identifier types are accepted provided they are expressed as RDF, but using PIDs in a consistent way 
-	allows us to unambiguously connect related works and contributors, improving data quality and discovery.  The RMap technical wiki includes some 
-	<a href="https://rmap-project.atlassian.net/wiki/spaces/RMAPPS/pages/198475777/RMap+DiSCO+Best+Practices" target="_blank">best practices</a> for 
+	allows us to unambiguously connect related works and contributors, improving data quality and discovery.  The RMap technical documentation includes some 
+	<a href="https://github.com/rmap-project/rmap-documentation/blob/master/guides/disco-design-best-practices.md" target="_blank">best practices</a> for 
 	linking and using these various related identifiers in a way that will encourage consistency around identifier use.
 	</p>
 	<c:if test="${SITEPROPS.isOrcidEnabled()}">
@@ -75,7 +75,7 @@
 	identifiers are referring to the same thing (person, article etc), they might also have different information or relationships associated with them. The 
 	user interface does not currently provide a way to condense these into a single view. As an example, a person might have an ORCID ID as well as an identity 
 	on a number of other platforms such as Scopus, Facebook, LinkedIn, and others. In the visualization these identities will appear as separate when in fact they 
-	all represent the same person. The RMap technical wiki includes some <a href="https://rmap-project.atlassian.net/wiki/spaces/RMAPPS/pages/198475777/RMap+DiSCO+Best+Practices" target="_blank">best practices</a> 
+	all represent the same person. The RMap technical wiki includes some <a href="https://github.com/rmap-project/rmap-documentation/blob/master/guides/disco-design-best-practices.md" target="_blank">best practices</a> 
 	for linking and using these various related identifiers in a way that will support better discovery and encourage consistency around identifier use.
 	</p>
 	
@@ -97,9 +97,9 @@
 		
 	<div id="additional-info"></div>
 	<h2>Additional information</h2>
-	<p>For additional information about RMap, visit the <a href="http://rmap-project.info/rmap/?page_id=98" target="_blank">RMap Project website</a>. 
+	<p>For additional information about RMap, visit the <a href="http://rmap-project.info" target="_blank">RMap Project information site</a>. 
 	To view the RMap code, report bugs, or request changes, visit the <a href="https://github.com/rmap-project/rmap" target="_blank">RMap GitHub project</a>. 
-	To read about technical detail of RMap including API instructions, visit the <a href="https://rmap-project.atlassian.net/wiki/spaces/RMAPPS/overview" target="_blank">RMap Techncial Wiki</a>. 
+	To read about technical detail of RMap including API instructions, view the <a href="https://github.com/rmap-project/rmap-documentation" target="_blank">RMap technical documentation</a>. 
 	For all other questions, please contact us at <a href="mailto:${SITEPROPS.getContactEmail()}">${SITEPROPS.getContactEmail()}</a></p>
 	<br/>
 <tl:pageEndStandard/>

--- a/webapp/src/main/webapp/WEB-INF/views/user/login.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/user/login.jsp
@@ -12,7 +12,7 @@
 		</p>
 	</c:if>
 	<p>Signing in to RMap allows you to initiate an RMap System Agent and manage API access keys that can be used to write DiSCOs to the RMap API. 
-	API documentation can be found on the <a href="https://rmap-project.atlassian.net/wiki">RMap technical wiki</a></p>
+	API documentation can be found in the <a href="https://github.com/rmap-project/rmap-documentation">RMap technical documentation</a></p>
 	<fieldset>
 	<ul>
 		<c:if test="${SITEPROPS.isGoogleEnabled()}">

--- a/webapp/src/main/webapp/WEB-INF/views/user/welcome.jsp
+++ b/webapp/src/main/webapp/WEB-INF/views/user/welcome.jsp
@@ -22,7 +22,7 @@
 	<h2>What can I do here?</h2>
 	<p>Logging in to RMap allows you to manage your write access to the RMap API. 
 	Read only access to the RMap API does not require an account.  
-	Documentation about how to use the RMap API can be found on the <a href="https://rmap-project.atlassian.net/wiki">RMap technical wiki</a>
+	Documentation about how to use the RMap API can be found in the <a href="https://github.com/rmap-project/rmap-documentation">RMap technical documentation</a>
 	To get write access to RMap through the API, carry out the following steps:</p>
 	<h3>Step 1: Create your RMap System Agent</h3>
 	<p>Creating a System Agent involves pushing some information about your identity into the RMap repository


### PR DESCRIPTION
This change updates all references to the tech wiki URL to instead point to the new `rmap-documentation` project in GitHub (https://github.com/rmap-project/rmap-documentation)

Also includes 2 minor bug fixes on API that were discovered while testing example code against the API:
* `currPage` can be null, this fixes a NPE for currPage on `/agents/{uri}/discos` and `/agents/{uri}/events`.
* Incorrect parameter was causing incorrect JSON output on `/api/events/{uri}/discos` path.

### Testing

I have put this and other changes in a combined .war deployment on test.rmap-hub.org. 

You can check the tech doc link points to the new location here:
https://test.rmap-hub.org/api/
and
https://test.rmap-hub.org/app/about#how-create-disco 

The `/agents/{uri}/discos` used to error, but now works:
https://test.rmap-hub.org/api/agents/ark%3A%2F99999%2Ffk4dn4j05g/discos

The `/events/{uri}/discos/` path used to show the wrong type URI. It now correctly shows "DiSCO":
https://test.rmap-hub.org/api/events/rmap%3A931zcrjsvw/discos 
Here it is broken in production:
https://rmap-hub.org/api/events/ark%3A%2F87281%2Ft2863gdf/discos 
