### PR TITLE
Ensure timezone always set to UTC

### DIFF
--- a/api/src/main/java/info/rmapproject/api/responsemgr/QueryParamHandler.java
+++ b/api/src/main/java/info/rmapproject/api/responsemgr/QueryParamHandler.java
@@ -23,6 +23,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MultivaluedMap;
@@ -73,6 +74,7 @@ public class QueryParamHandler {
 			String until = queryParams.getFirst(Constants.UNTIL_PARAM);
 			if (until==null || until.trim().length()==0){
 				DateFormat df = new SimpleDateFormat(DATE_STRING_FORMAT);
+				df.setTimeZone(TimeZone.getTimeZone("UTC"));
 				Date thisMoment = Calendar.getInstance().getTime();        
 				String untilNow = df.format(thisMoment);
 				until=untilNow;

--- a/api/src/main/java/info/rmapproject/api/utils/Constants.java
+++ b/api/src/main/java/info/rmapproject/api/utils/Constants.java
@@ -82,7 +82,7 @@ public final class Constants  {
 	public static final String HTTP_HEADER_ACCEPT_DATETIME = "Accept-Datetime";
 	
 	/** Date format for dates in Response header e.g. Link datetime, Memento-Datetime**/
-	public static final String HTTP_HEADER_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
+	public static final String HTTP_HEADER_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss z";
 	
 	/**
   	* Instantiates a new constants.

--- a/api/src/main/java/info/rmapproject/api/utils/HttpHeaderDateUtils.java
+++ b/api/src/main/java/info/rmapproject/api/utils/HttpHeaderDateUtils.java
@@ -23,6 +23,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 public class HttpHeaderDateUtils {
 	
@@ -53,6 +54,7 @@ public class HttpHeaderDateUtils {
 	public static String convertDateToString(Date date)
 	throws NullPointerException, IllegalArgumentException {
 		DateFormat format = new SimpleDateFormat(Constants.HTTP_HEADER_DATE_FORMAT);
+		format.setTimeZone(TimeZone.getTimeZone("GMT")); //must be displayed as GMT (https://tools.ietf.org/html/rfc7089)
 		String dateString = format.format(date);
 		return dateString;
 	}

--- a/api/src/test/java/info/rmapproject/api/responsemgr/versioning/ResourceVersionsTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/versioning/ResourceVersionsTest.java
@@ -66,7 +66,7 @@ public class ResourceVersionsTest {
 	 */
 	@Before
 	public void setUp() throws Exception {
-		
+
 		date1 = sdf.parse(sdate1);
 		date2 = sdf.parse(sdate2);
 		date3 = sdf.parse(sdate3);

--- a/api/src/test/java/info/rmapproject/api/responsemgr/versioning/TimegateTest.java
+++ b/api/src/test/java/info/rmapproject/api/responsemgr/versioning/TimegateTest.java
@@ -73,7 +73,7 @@ public class TimegateTest {
 	 */
 	@Before
 	public void setUp() throws Exception {
-		
+
 		timegate = new TimegateImpl();
 		
 		date1 = sdf.parse(sdate1);

--- a/api/src/test/java/info/rmapproject/api/utils/HttpHeaderDateUtilsTestIT.java
+++ b/api/src/test/java/info/rmapproject/api/utils/HttpHeaderDateUtilsTestIT.java
@@ -20,7 +20,6 @@ import info.rmapproject.api.ApiTestAbstractIT;
  * @author khanson5
  *
  */
-@Ignore("TODO: Pending resolution of #46")
 public class HttpHeaderDateUtilsTestIT extends ApiTestAbstractIT {
 
 	private Date dTestdate1;
@@ -36,11 +35,11 @@ public class HttpHeaderDateUtilsTestIT extends ApiTestAbstractIT {
 
 			String sdate = "Tue Nov 18 08:11:30 EST 2014";
 			this.dTestdate1 = df.parse(sdate); 
-			this.sTestdate1 = "Tue, 18 Nov 2014 08:11:30 EST";
+			this.sTestdate1 = "Tue, 18 Nov 2014 13:11:30 GMT"; //5 hours later
 
-			sdate = "Wed Feb 08 18:41:30 EST 2017";
+			sdate = "Wed Feb 08 18:41:30 GMT 2017";
 			this.dTestdate2 = df.parse(sdate); 
-			this.sTestdate2 = "Wed, 08 Feb 2017 18:41:30 EST";
+			this.sTestdate2 = "Wed, 08 Feb 2017 18:41:30 GMT"; //same as GMT
 			
 		} catch (Exception ex){
 			fail("Problem while populating properties during test startup");
@@ -56,10 +55,11 @@ public class HttpHeaderDateUtilsTestIT extends ApiTestAbstractIT {
 	public void testConvertDateToString() {
 		try {
 			String mementodate = HttpHeaderDateUtils.convertDateToString(dTestdate1);
-			assertTrue(mementodate.equals(sTestdate1));		
+      
+			assertTrue(mementodate + " not the same as " + sTestdate1, mementodate.equals(sTestdate1));		
 			
 			String mementodate2 = HttpHeaderDateUtils.convertDateToString(dTestdate2);
-			assertTrue(mementodate2.equals(sTestdate2));	
+			assertTrue(mementodate + " not the same as " + sTestdate2,mementodate2.equals(sTestdate2));	
 		} catch (Exception ex){
 			fail("Problem while testing convertStringToDate(Date)");
 		}
@@ -73,17 +73,17 @@ public class HttpHeaderDateUtilsTestIT extends ApiTestAbstractIT {
 	public void testConvertStringToDate() {
 		try {
 			Date mementodate = HttpHeaderDateUtils.convertStringToDate(sTestdate1);
-			assertTrue(mementodate.equals(dTestdate1));		
+			assertTrue(mementodate + " not the same as " + sTestdate1,mementodate.equals(dTestdate1));		
 			
 			Date mementodate2 = HttpHeaderDateUtils.convertStringToDate(sTestdate2);
-			assertTrue(mementodate2.equals(dTestdate2));
+			assertTrue(mementodate2 + " not the same as " + sTestdate2,mementodate2.equals(dTestdate2));
 
 			//now use convertDateToString to switch back.
 			String smementodate = HttpHeaderDateUtils.convertDateToString(mementodate2);
-			assertTrue(smementodate.equals(sTestdate2));	
+			assertTrue(smementodate + " not the same as " + sTestdate2,smementodate.equals(sTestdate2));	
 			
 		} catch (Exception ex){
-			fail("Problem while testing convertStringToDate(String)");			
+			fail("Problem while testing convertStringToDate(String)");
 		}
 	}
 

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapResourceMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapResourceMgrTest.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import info.rmapproject.core.model.request.RMapSearchParamsFactory;
 import org.junit.After;
@@ -79,8 +80,11 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 	@Autowired
 	RMapSearchParamsFactory paramsFactory;
 
+	private DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+	
 	@Before
 	public void setUp() throws Exception {
+		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 		createSystemAgent();
 	}
 
@@ -104,7 +108,7 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 			Set <URI> sysAgents = new HashSet<URI>();
 			sysAgents.add(new URI(TestConstants.SYSAGENT_ID));
 			
-			DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+			dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 			Date dateFrom = dateFormat.parse("2014-1-1");
 			Date dateTo = dateFormat.parse("2050-1-1");
 		
@@ -152,7 +156,6 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 			Set <URI> sysAgents = new HashSet<URI>();
 			sysAgents.add(new URI(TestConstants.SYSAGENT_ID));
 			
-			DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 			Date dateFrom = dateFormat.parse("2014-1-1");
 			Date dateTo = dateFormat.parse("2050-1-1");
 		
@@ -195,7 +198,6 @@ public class ORMapResourceMgrTest extends ORMapMgrTest {
 			Set <URI> sysAgents = new HashSet<URI>();
 			sysAgents.add(new URI(TestConstants.SYSAGENT_ID));
 			
-			DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 			Date dateFrom = dateFormat.parse("2014-1-1");
 			Date dateTo = dateFormat.parse("2050-1-1");
 		

--- a/core/src/test/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapStatementMgrTest.java
+++ b/core/src/test/java/info/rmapproject/core/rmapservice/impl/rdf4j/ORMapStatementMgrTest.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.TimeZone;
 
 import org.junit.Test;
 import org.eclipse.rdf4j.model.IRI;
@@ -78,6 +79,7 @@ public class ORMapStatementMgrTest extends ORMapMgrTest {
 		sysAgents.add(new URI(TestConstants.SYSAGENT_ID));
 		
 		DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 		Date dateFrom = dateFormat.parse("2014-1-1");
 		Date dateTo = dateFormat.parse("2050-1-1");
 		IRI subject = ORAdapter.getValueFactory().createIRI(TestConstants.TEST_DISCO_DOI);
@@ -117,6 +119,7 @@ public class ORMapStatementMgrTest extends ORMapMgrTest {
 		sysAgents.add(new URI(TestConstants.SYSAGENT_ID));
 		
 		DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 		Date dateFrom = dateFormat.parse("2014-1-1");
 		Date dateTo = dateFormat.parse("2050-1-1");
 		IRI subject = ORAdapter.getValueFactory().createIRI(TestConstants.TEST_DISCO_DOI);


### PR DESCRIPTION
Fixes 2 timezone issues:

1) When using the `Accept-Datetime`, the server was ignoring the timezone and assuming the timezone was whatever the server was set to. The utility now respects the timezone provided, and the string date is returned as GMT per Memento requirement. This issue is described in #46. I have re-enabled the corresponding tests.

2) Defines TimeZone as UTC on date filter queries in core - so when someone queries the API with a date it assumes that date is UTC every time. This keeps date filters consistent. Previously, it was applying date filter based on timezone of the server, so you would get different results depending on the region of timezone of the server.

Closes #46 

### Testing

I have combined this and other PR changes in a new version available through test.rmap-hub.org. 

For the first issue, you can see that GMT is applied here:
https://test.rmap-hub.org/api/discos/ark%3A%2F99999%2Ffk48346261/timemap
and in the headers of this:
https://test.rmap-hub.org/api/discos/ark%3A%2F99999%2Ffk48346261

Compare to previous that was using the server region:
https://rmap-hub.org/api/discos/ark%3A%2F87281%2Ft2zg7s8v/timemap
headers here:
https://rmap-hub.org/api/discos/ark%3A%2F87281%2Ft2zg7s8v

The second issue is tricky to test. I noticed it because when you create a DiSCO after 7PM in certain circumstances, the server was interpreting it as being created tomorrow and so applying the current date as a filter through the UI or API did not return the DiSCO you just created. This just enforces some consistency.