### PR TITLE
Expose Event's rmap:lineageProgenitor through API

### DIFF
--- a/core/src/main/java/info/rmapproject/core/model/impl/rdf4j/ORMapEvent.java
+++ b/core/src/main/java/info/rmapproject/core/model/impl/rdf4j/ORMapEvent.java
@@ -483,6 +483,9 @@ public abstract class ORMapEvent extends ORMapObject implements RMapEvent {
 		eventModel.add(eventTypeStmt);
 		eventModel.add(eventTargetTypeStmt);
 		eventModel.add(startTimeStmt);
+		if (lineageProgenitorStmt != null){
+			eventModel.add(lineageProgenitorStmt);
+		}
 		if (endTimeStmt != null){
 			eventModel.add(endTimeStmt);
 		}


### PR DESCRIPTION
The `rmap:lineageProgenitor` was not being exposed through the `GET /rmap/events/{uri}` API. This adds it to the getModel() for Event.

### Testing

I have loaded this combined with other changes to the test server. You can see the result here:
https://test.rmap-hub.org/api/events/ark%3A%2F99999%2Ffk4jq1bz77 
(`lineageProgenitor` is now present)
Previously, no lineageProgenitor:
https://rmap-hub.org/api/events/ark%3A%2F87281%2Ft2863gdf